### PR TITLE
Add test for #27: Unicode in INI file

### DIFF
--- a/kotti/tests/test_util_views.py
+++ b/kotti/tests/test_util_views.py
@@ -60,9 +60,9 @@ class TestTemplateAPI(UnitTestBase):
 
     @patch('kotti.views.util.get_settings')
     def test_site_title_with_non_ascii_characters(self, get_settings):
-        get_settings.return_value = {'kotti.site_title': 'K\xc3\xb6tti'}#Kötti
+        get_settings.return_value = {'kotti.site_title': u'Kötti'}
         api = self.make()
-        self.assertEqual(api.site_title, u'K\xf6tti')
+        self.assertEqual(api.site_title, u'Kötti')
 
     @patch('kotti.views.util.has_permission')
     def test_list_children(self, has_permission):

--- a/kotti/views/util.py
+++ b/kotti/views/util.py
@@ -128,7 +128,7 @@ class TemplateAPI(object):
         value = get_settings().get('kotti.site_title')
         if not value:
             value = self.root.title
-        return value.decode('utf-8')
+        return value
 
     @reify
     def page_title(self):


### PR DESCRIPTION
Just add a test that simply checks for use of Unicode on `kotti.site_title` setting
