### PR TITLE
Move test for #27: Unicode in INI file

### DIFF
--- a/kotti/tests/test_app.py
+++ b/kotti/tests/test_app.py
@@ -147,3 +147,13 @@ class TestApp(UnitTestBase):
         settings = self.required_settings()
         settings['kotti.includes'] = (self._includeme_layout,)
         return self.test_render_master_edit_template_with_minimal_root(settings)
+
+    def test_setting_values_as_unicode(self):
+        from kotti import get_settings
+        from kotti import main
+
+        settings = self.required_settings()
+        settings['kotti.site_title'] = 'K\xc3\xb6tti' # Kötti
+
+        main({}, **settings)
+        self.assertEqual(get_settings()['kotti.site_title'], u'K\xf6tti')

--- a/kotti/tests/test_util_views.py
+++ b/kotti/tests/test_util_views.py
@@ -58,12 +58,6 @@ class TestTemplateAPI(UnitTestBase):
         api = self.make()
         self.assertEqual(api.site_title, u'This is it.')
 
-    @patch('kotti.views.util.get_settings')
-    def test_site_title_with_non_ascii_characters(self, get_settings):
-        get_settings.return_value = {'kotti.site_title': u'Kötti'}
-        api = self.make()
-        self.assertEqual(api.site_title, u'Kötti')
-
     @patch('kotti.views.util.has_permission')
     def test_list_children(self, has_permission):
         has_permission.return_value = True


### PR DESCRIPTION
Test moved to `kotti.tests.test_app`
