### PR TITLE
Accelerate file downloads by serveral thousand percents (if your files are large enough)

### DIFF
--- a/kotti/views/file.py
+++ b/kotti/views/file.py
@@ -50,10 +50,9 @@ def inline_view(context, request, disposition='inline'):
                 disposition, context.filename.encode('ascii', 'ignore'))),
             ('Content-Length', str(context.size)),
             ('Content-Type', str(context.mimetype)),
-            ],
-        app_iter=context.data,
+            ]
         )
-
+    res.body = context.data
     return res
 
 def attachment_view(context, request):


### PR DESCRIPTION
Instead of constructing the response body by iterating over the file_data, the body should be assigned as a single string at once.

Download time for a 1.5MB file has been > 25 seconds (at 100% CPU) before the change and is down to 60 ms after the change (on my development machine.
