### PR TITLE
Quick fix patch to edit a group information

### DIFF
--- a/kotti/tests/browser.txt
+++ b/kotti/tests/browser.txt
@@ -507,6 +507,14 @@ from Bob's Group:
   >>> ctrl(name="role::bob::role:viewer").disabled
   True
 
+We can click on the Bob's Group entry to edit an email address:
+
+  >>> browser.getLink("Bob's Group").click()
+  >>> ctrl(name="email").value = 'bogsgroup@gmail.com'
+  >>> ctrl(name="save").click()
+  >>> "Your changes have been saved" in browser.contents
+  True
+
 Set password
 ------------
 

--- a/kotti/views/users.py
+++ b/kotti/views/users.py
@@ -255,8 +255,8 @@ def _massage_groups_out(appstruct):
     """
     d = appstruct
     groups = [g.split(u'group:')[1] for g in d['groups']
-              if g.startswith(u'group:')]
-    roles = [r for r in d['groups'] if r.startswith(u'role:')]
+              if g and g.startswith(u'group:')]
+    roles = [r for r in d['groups'] if r and r.startswith(u'role:')]
     d['groups'] = groups
     d['roles'] = roles
     return d
@@ -377,19 +377,31 @@ class UserManageFormView(UserEditFormView):
         _massage_groups_in(appstruct)
         return super(UserEditFormView, self).save_success(appstruct)
 
+class GroupManageFormView(UserManageFormView):
+    def schema_factory(self):
+        schema = group_schema()
+        del schema['name']
+        del schema['active']
+        return schema
+
 def user_manage(context, request):
-    username = request.params['name']
-    principal = get_principals()[username]
+    user_or_group = request.params['name']
+    principal = get_principals()[user_or_group]
+
+    is_group = user_or_group.startswith("group:")
+    principal_type = u"Group" if is_group else u"User"
 
     api = template_api(
         context, request,
-        page_title=_(u"Edit User - ${title}",
-                     mapping=dict(title=context.title)),
+        page_title=_(u"Edit ${principal_type} - ${title}",
+                     mapping=dict(principal_type=principal_type,
+                                  title=context.title)),
         cp_links=CONTROL_PANEL_LINKS,
         principal=principal,
         )
 
-    form = UserManageFormView(principal, request)()
+    form_view = GroupManageFormView if is_group else UserManageFormView
+    form = form_view(principal, request)()
     if request.is_response(form):
         return form
 


### PR DESCRIPTION
As you know, the edit groups screen is not correct. I found a TODO as below. I think it's better to be able to update a group information until implementing the proper group screen.

> commit 87cb66cbb9c8061dba65f3b37af71374dbfb53c5
> Author: Daniel Nouri daniel.nouri@gmail.com> 
> Date:   Mon Mar 7 15:27:10 2011 +0100
> 
> ```
> Add user management screen.
> TODO: Edit screens for individual users/groups.
> ```

How to reproduce:
1. add a group information in user management screen
2. select the group you made
3. edit the item of groups
4. click "save" button, then the change is updated
