### PR TITLE
add simple makefile for conveniently gettings things up and running...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+
+version = 2.7
+python = python$(version)
+
+test: bin/py.test
+	bin/py.test -q -n4
+
+bin/py.test: bin/python *.py *.cfg
+	bin/python setup.py dev
+	@touch $@
+
+bin/python:
+	virtualenv-$(version) --no-site-packages --distribute .
+	@touch $@
+
+clean:
+	@rm -rfv bin/ include/ lib/
+
+.PHONY: test clean
+


### PR DESCRIPTION
this runs virtualenv, setup.py & the tests, just type `make`…

it also provides a `make clean` target to easily remove potentially outdated dependencies.
