### PR TITLE
Adding duplicated email validator patch

### DIFF
--- a/kotti/tests/browser.txt
+++ b/kotti/tests/browser.txt
@@ -482,6 +482,7 @@ Use a valid username now.  Note how the checkbox to send a password
 registration link is ticked:
 
   >>> ctrl("Name", index=0).value = u"Bob"
+  >>> ctrl("Email", index=0).value = "bob@dabolina.com"
   >>> ctrl("Send password registration link", index=0).selected
   True
   >>> ctrl(name="add_user").click()
@@ -492,11 +493,25 @@ We cannot add Bob twice:
 
   >>> ctrl("Name", index=0).value = "bob"
   >>> ctrl("Full name", index=0).value = "Bobby Brown"
-  >>> ctrl("Email", index=0).value = "bob@gmail.com"
   >>> ctrl("Password", index=0).value = "secret"
   >>> ctrl(name='password-confirm').value = "secret"
   >>> ctrl(name="add_user").click()
   >>> "A user with that name already exists" in browser.contents
+  True
+
+We cannot add Bob Dabolina's email twice:
+
+  >>> ctrl("Name", index=0).value = "bob2"
+  >>> ctrl("Full name", index=0).value = "Bobby Brown"
+  >>> ctrl("Email", index=0).value = "bob@dabolina.com"
+  >>> ctrl("Password", index=0).value = "secret"
+  >>> ctrl(name='password-confirm').value = "secret"
+  >>> ctrl(name="add_user").click()
+  >>> "A user with that email already exists" in browser.contents
+  True
+  >>> ctrl("Email", index=0).value = "bob@gmail.com"
+  >>> ctrl(name="add_user").click()
+  >>> "Bobby Brown" in browser.contents
   True
 
 Searching for Bob will return both Bob and Bob's Group:
@@ -521,6 +536,17 @@ to:
   >>> ctrl(name="group").value = "bobsgroup"
   >>> ctrl(name="save").click()
   >>> "Your changes have been saved" in browser.contents
+  True
+
+We cannot update on the Bobby Brown's entry with duplicated email:
+
+  >>> browser.getLink("Back to User Management").click()
+  >>> ctrl(name="query").value = "Bobby"
+  >>> ctrl(name="search").click()
+  >>> browser.getLink("Bobby Brown").click()
+  >>> ctrl("Email", index=0).value = "bob@dabolina.com"
+  >>> ctrl(name="save").click()
+  >>> "A user with that email already exists" in browser.contents
   True
 
 If we cancel the edit of the user, we are redirected to the user management
@@ -561,7 +587,8 @@ Set password
 Remember that we sent Bob an email for registration.  He can use it to
 set his own password:
 
-  >>> [email] = mailer.outbox
+  >>> [email1, email2] = mailer.outbox
+  >>> email = email1 if email1.recipients[0].startswith('"Bob Dabolina"') else email2
   >>> print email.recipients
   [u'"Bob Dabolina" <bob@dabolina.com>']
   >>> print email.subject
@@ -621,8 +648,8 @@ The login form has a "Reset password" button.  Let's try it:
   >>> "You should receive an email" in browser.contents
   True
 
-  >>> [email1, email2] = mailer.outbox
-  >>> print email2.body # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+  >>> [email1, email2, email3] = mailer.outbox
+  >>> print email3.body # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
   Hello, Bob Dabolina!
   Click this link to reset your password at Website des Kottbusser Tors:...
 


### PR DESCRIPTION
I found a bug when I set and save the duplicated email in User Management.

As you know, checking the duplicated email is a little complicated. Because, an email field has to be checked with the name field. I found the "colander.deferred" function to solve this problem though it's a little dirty. :(

http://docs.pylonsproject.org/projects/colander/en/latest/binding.html

I confirmed that 2 pattern tests (create user and update user info) are passed. Could you review my patch?
