### PR TITLE
Added context and user as attributes to the view request for rendering slots.

### DIFF
--- a/kotti/tests/test_util_views.py
+++ b/kotti/tests/test_util_views.py
@@ -237,11 +237,13 @@ class TestTemplateAPI(UnitTestBase):
         with raises(KeyError):
             assign_slot('viewname', 'noslotlikethis')
 
-    def test_slot_request_has_registry(self):
+    def test_slot_request_has_attributes(self):
         from kotti.views.slots import assign_slot
 
         def my_viewlet(request):
             assert hasattr(request, 'registry')
+            assert hasattr(request, 'context')
+            assert hasattr(request, 'user')
             return Response(u"Hello world!")
         assign_slot('my-viewlet', 'right')
 

--- a/kotti/views/slots.py
+++ b/kotti/views/slots.py
@@ -71,7 +71,9 @@ def _render_view_on_slot_event(view_name, event, params):
         base_url=request.application_url,
         POST=_encode(params),
         )
+    view_request.context = request.context
     view_request.registry = request.registry
+    view_request.user = request.user
     try:
         result = render_view(
             context,


### PR DESCRIPTION
Needed to use the new assign_slot style in kotti_navigation.
