### PR TITLE
Enable deferred loading on File.data column.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,8 @@ Change History
 
 - Fix #91: Styling of search box.
 
+- Enabled deferred loading on File.data column.
+
 0.7a4 - 2012-06-25
 ------------------
 

--- a/kotti/resources.py
+++ b/kotti/resources.py
@@ -6,6 +6,7 @@ from pyramid.traversal import resource_path
 from sqlalchemy.sql import and_
 from sqlalchemy.sql import select
 from sqlalchemy.orm import backref
+from sqlalchemy.orm import deferred
 from sqlalchemy.orm import object_mapper
 from sqlalchemy.orm import relation
 from sqlalchemy.orm.exc import NoResultFound
@@ -257,7 +258,6 @@ class TagsToContents(Base):
     tag = relation(Tag, backref=backref('content_tags', cascade='all'))
     position = Column(Integer, nullable=False)
     title = association_proxy('tag', 'title')
-
     @classmethod
     def _tag_find_or_create(self, title):
         with DBSession.no_autoflush:
@@ -347,7 +347,7 @@ class Document(Content):
 
 class File(Content):
     id = Column(Integer(), ForeignKey('contents.id'), primary_key=True)
-    data = Column(LargeBinary())
+    data = deferred(Column(LargeBinary()))
     filename = Column(Unicode(100))
     mimetype = Column(String(100))
     size = Column(Integer())


### PR DESCRIPTION
File object loading is slow because the file data gets fetched from the DB per default. I changed the column to deferred loading (data gets loaded on attribute access, not on query), as this should be reasonable for most use cases. For my use case, it really boosts the page request time.
