### PR TITLE
Quickfix to get pylons_sphinx_theme with setuptools/distutils commands

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,7 +93,8 @@ pygments_style = 'sphinx'
 # -- Options for HTML output ---------------------------------------------------
 
 # Add and use Pylons theme
-if 'sphinx-build' in ' '.join(sys.argv): # protect against dumb importers
+sys_argv = ' '.join(sys.argv)  # protect against dumb importers
+if any(map(lambda x: x in sys_argv, ['sphinx-build','build_sphinx'])):
     from subprocess import call, Popen, PIPE
 
     p = Popen('which git', shell=True, stdout=PIPE)


### PR DESCRIPTION
The docs/conf.py expects only using Makefile to build the documentation. But, I know another way to build a sphinx documentation as below.

``` bash
$ python setup.py build_sphinx
```

I fixed to get the pylons theme with both way. Could you review it on your environment?
