### PR TITLE
Fixed the lack of a sender attribute for Message object

### DIFF
--- a/kotti/message.py
+++ b/kotti/message.py
@@ -112,12 +112,21 @@ def send_set_password(user, request, templates='set-password', add_query=None):
     if isinstance(templates, str):
         templates = message_templates[templates]
     message = Message(
+        sender=get_message_sender(),
         recipients=[u'"%s" <%s>' % (user.title, user.email)],  # XXX naive?
         subject=templates['subject'] % variables,
         body=templates['body'] % variables,
         )
     mailer = get_mailer()
     mailer.send(message)
+
+
+def get_message_sender(sender_user=None):
+    sender = sender_user or 'Kotti Administrator'
+    sender_address = get_settings().get('mail.default_sender')
+    if sender_address:
+        sender += ' <%s>' % sender_address
+    return sender
 
 
 def email_set_password(user, request,
@@ -147,6 +156,7 @@ def email_set_password(user, request,
     textbody = html2text.handle(htmlbody).strip()
 
     message = Message(
+        sender=get_message_sender(),
         recipients=[u'"%s" <%s>' % (user.title, user.email)],  # XXX naive?
         subject=subject,
         body=textbody,

--- a/kotti/tests/test_message.py
+++ b/kotti/tests/test_message.py
@@ -60,6 +60,7 @@ class TestSendSetPassword(UnitTestBase):
 
         assert self.mailer.send.called
         message = self.mailer.send.call_args[0][0]
+        assert message.sender.startswith('Kotti Administrator')
         assert message.subject == 'Hey there Joe'
         assert message.body == 'This is Awesome site speaking'
 
@@ -115,6 +116,7 @@ class TestEmailSetPassword(UnitTestBase):
         assert hasattr(user, 'confirm_token')
         assert self.mailer.send.called
         message = self.mailer.send.call_args[0][0]
+        assert message.sender.startswith('Kotti Administrator')
         assert message.subject.startswith('Your registration')
         assert 'Joe' in message.body
         assert 'Joe' in message.html


### PR DESCRIPTION
I got an error below when I try to make a user enabled "Send password registration link".

```
pyramid_mailer.exceptions.InvalidMessage
InvalidMessage: No sender address has been set
```

According to pyramid_mailer validation, the Message object needs a sender attribute.
