### PR TITLE
The name of projects on readthedocs should have dashes, and not undersco...

### DIFF
--- a/docs/developing/developer-manual.rst
+++ b/docs/developing/developer-manual.rst
@@ -297,7 +297,7 @@ is used for making screen captures, and thereby helps to actually test Kotti in
 the process. `blockdiag`_ is used to make flow charts and diagrams interjected
 into the docs.
 
-.. _Kotti User Manual: https://kotti_user_manual.readthedocs.org
+.. _Kotti User Manual: https://kotti-user-manual.readthedocs.org
 
 .. _Selenium: http://selenium-python.readthedocs.org
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@ browsing or searching, or were referred here, you will want to go directly to
 the `Kotti User Manual`_ The documentation below, ``First Steps``, ``Topics``,
 and so on, are for developers of Kotti. 
 
-.. _Kotti User Manual: http://kotti_user_manual.readthedocs.org/
+.. _Kotti User Manual: http://kotti-user-manual.readthedocs.org/
 
 First Steps
 -----------
@@ -66,7 +66,7 @@ The `Kotti User Manual`_ is rendered and hosted on readthedocs.org.
 Developers, please see the :ref:`developer_manual` for instructions on
 contributing to the user manual.
 
-.. _Kotti User Manual: http://kotti_user_manual.readthedocs.org/
+.. _Kotti User Manual: http://kotti-user-manual.readthedocs.org/
 
 Changes
 -------


### PR DESCRIPTION
...res. Their server was not redirecting properly from the / URL to the en/latest URL (a problem they will address later). So, the user manual was renamed from kotti_user_manual to kotti-user-manual, and rebuilt, and our links updated.
