### PR TITLE
Partial fix (read questions please): Problems with copy-paste of nodes.

### DIFF
--- a/kotti/views/edit/actions.py
+++ b/kotti/views/edit/actions.py
@@ -138,8 +138,8 @@ class NodeActions(object):
         :rtype: pyramid.httpexceptions.HTTPFound
         """
         ids, action = self.request.session['kotti.paste']
-        for id in ids:
-            item = DBSession.query(Node).get(id)
+        items = [DBSession.query(Node).get(id) for id in ids]
+        for item in items:
             if item is not None:
                 if action == 'cut':
                     if not has_permission('edit', item, self.request):


### PR DESCRIPTION
Partial fix for #255 and minor cleaning. 

Moved the if for deleting self.request.session['kotti.paste'] out of the for loop so it's cleaner (we get rid of the count and enumerate(ids), plus we only need one if now instead of (n)). 

Partially fixed #255 - we go through the nodes before we start copying now, which does help in some cases. The problem, however, persists if we not only delete some nodes, but after that add some new ones. When we paste, we will get the newly created nodes out of the database instead of the old ones. 

PS: This is related to #257, but I separated them because I feel this is way more important (this can cause actual problems) then cleaning up the flash messages, especially because that one could take a while to get merged because of translations. 
