### PR TITLE
Add a label next to each item in @@navigate to show what the content type is

### DIFF
--- a/kotti/templates/edit/nav-tree.pt
+++ b/kotti/templates/edit/nav-tree.pt
@@ -8,6 +8,7 @@
     <a tal:condition="api.find_edit_view(child)"
        href="${api.url(child, '@@edit')}"
        title="Edit" i18n:attributes="title"><i class="icon-edit"></i></a>
+    <em>(${child.type_info.title})</em>
     <ul tal:replace="api.render_template(
                          'kotti:templates/edit/nav-tree.pt',
                          tree=child)" />


### PR DESCRIPTION
At the moment it is quite difficult to distinguish between different types of content.
