### PR TITLE
Fix wsgi_intercept to 0.5.1, since tests stop working with 0.6.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ tests_require = [
     'pytest-cov',
     'pytest-pep8!=1.0.3',
     'pytest-xdist',
-    'wsgi_intercept',
+    'wsgi_intercept==0.5.1',
     'zope.testbrowser',
     ]
 


### PR DESCRIPTION
With the latest version (0.6), tests are broken. From the GitHub README at (https://github.com/cdent/python3-wsgi-intercept), it says:

> If you are using Python 2 and need support for a different HTTP client, require a version of wsgi_intercept<0.6.

Would probably be better to move to latest version and change the tests, but this is faster :)
