### PR TITLE
Include groups in Node ACL if specified in workflow configuration. Fixes #278

### DIFF
--- a/kotti/workflow.py
+++ b/kotti/workflow.py
@@ -53,7 +53,8 @@ def workflow_callback(context, info):
 
     # This could definitely be cached...
     for key, value in state_data.items():
-        if key.startswith('role:') or key == 'system.Everyone':
+        if (key.startswith('role:') or key.startswith('group:') or
+           key == 'system.Everyone'):
             for perm in value.split():
                 acl.append(("Allow", key, perm))
 


### PR DESCRIPTION
Here is my workflow confguration:

<state name="public" callback="leanneodea.workflow.workflow_callback">

```
  <key name="title" value="_(u'Public')" />
  <key name="order" value="2" />

  <key name="inherit" value="0" />
  <key name="system.Everyone" value="view" />
  <key name="role:viewer" value="view" />
  <key name="role:editor" value="view add edit state_change" />
  <key name="role:owner" value="view add edit manage state_change" />
  <key name="group:publisher" value="view add edit state_change" />
```

</state>

I want users in a publisher group to only be able to view and publish content, currently there is no way of easily doing so that I can see.  The group:publisher key is being ignored. Fix attached.
