### PR TITLE
Fixing the links to the third tutorial

### DIFF
--- a/docs/first_steps/tut-3.rst
+++ b/docs/first_steps/tut-3.rst
@@ -1,4 +1,4 @@
-.. _tut-1:
+.. _tut-3:
 
 Tutorial Part 3: User interaction
 =================================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ First Steps
     first_steps/installation
     first_steps/tut-1
     first_steps/tut-2
+    first_steps/tut-3
 
 Topics
 ------


### PR DESCRIPTION
Having the third tutorial is nice, but it's even better when it actually shows in the index and is properly linked from somewhere - don't know how I missed that before o.O
