### PR TITLE
Fix requirements.txt for pyramid-mako changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ py-bcrypt==0.3
 pyramid==1.5a2
 pyramid-beaker==0.7
 pyramid-chameleon==0.1
-pyramid-debugtoolbar==1.0.8
+pyramid-debugtoolbar==1.0.9
 pyramid-deform==0.2a5
 pyramid-mailer==0.11
 pyramid-tm==0.7


### PR DESCRIPTION
pyramid-mako 0.3 drops MakoRendererFactoryHelper. pyramid-debugtoolbar 1.0.9 correctly uses the new add_mako_renderer directive.
