### PR TITLE
Adjusted permissions for contents and workflow dropdown views.

### DIFF
--- a/kotti/tests/browser.txt
+++ b/kotti/tests/browser.txt
@@ -610,33 +610,23 @@ Contents view change state actions
   True
 
 
-Check permissions of contents view and workflow dropdown
---------------------------------------------------------
-
-  >>> browser.open(testing.BASE_URL + '/@@contents')
-  >>> '<table id="contents-table"' in browser.contents
-  True
+Check permission of workflow dropdown
+-------------------------------------
 
   >>> browser.open(testing.BASE_URL + '/@@workflow-dropdown')
   >>> '<ul class="dropdown-menu">' in browser.contents
   True
 
-Logout, and check that the views are not accessible:
+Logout, and check that the view is not accessible:
 
   >>> browser.open(testing.BASE_URL + '/@@logout')
-  >>> browser.open(testing.BASE_URL + '/@@contents')
-  >>> '<table id="contents-table"' in browser.contents
-  False
-  >>> '<div class="login-form">' in browser.contents
-  True
-
   >>> browser.open(testing.BASE_URL + '/@@workflow-dropdown')
   >>> '<ul class="dropdown-menu">' in browser.contents
   False
   >>> '<div class="login-form">' in browser.contents
   True
 
-Log in again :
+Log in again:
 
   >>> ctrl("Username or email").value = "admin"
   >>> ctrl("Password").value = "secret"

--- a/kotti/views/edit/actions.py
+++ b/kotti/views/edit/actions.py
@@ -474,7 +474,7 @@ def content_type_factories(context, request):
     return {'factories': factories}
 
 
-@view_config(context=IContent, name='contents', permission='edit',
+@view_config(context=IContent, name='contents', permission='view',
              renderer='kotti:templates/edit/contents.pt')
 def contents(context, request):
     """


### PR DESCRIPTION
Currently the @@contens and @@workflow-dropdown views are reachable for anonymous users. It's not possible to change anything, but it should not be possible to get this intern information.
