### PR TITLE
Fixes i18n domain in email messages templates.

### DIFF
--- a/kotti/templates/email-reset-password.pt
+++ b/kotti/templates/email-reset-password.pt
@@ -1,4 +1,4 @@
-<tal:block i18n:domain="kotti">
+<tal:block i18n:domain="Kotti">
 Subject: <tal:block i18n:translate="">Reset your password for <span tal:replace="site_title" i18n:name="site_title" />.</tal:block>
 
 <p i18n:translate="">Hello, <span tal:replace="user_title" i18n:name="user_title" />!</p>

--- a/kotti/templates/email-set-password.pt
+++ b/kotti/templates/email-set-password.pt
@@ -1,4 +1,4 @@
-<tal:block i18n:domain="kotti">
+<tal:block i18n:domain="Kotti">
 Subject: <tal:block i18n:translate="">Your registration for <span tal:replace="site_title" i18n:name="site_title" /></tal:block>
 
 <p i18n:translate="">Hello, <span tal:replace="user_title" i18n:name="user_title" />!</p>


### PR DESCRIPTION
The translation of the email messages did not work due to a wrong i18n domain.
