### PR TITLE
Fixes persistence of cleanup user groups after a group deletion.

### DIFF
--- a/kotti/security.py
+++ b/kotti/security.py
@@ -20,6 +20,7 @@ from pyramid.security import view_execution_permitted
 from kotti import get_settings
 from kotti import DBSession
 from kotti import Base
+from kotti.sqla import MutationList
 from kotti.sqla import JsonType
 from kotti.util import _
 from kotti.util import request_cache
@@ -72,12 +73,12 @@ class Principal(Base):
     confirm_token = Column(Unicode(100))
     title = Column(Unicode(100), nullable=False)
     email = Column(Unicode(100), unique=True)
-    groups = Column(JsonType(), nullable=False)
+    groups = Column(MutationList.as_mutable(JsonType), nullable=False)
     creation_date = Column(DateTime(), nullable=False)
     last_login_date = Column(DateTime())
 
     def __init__(self, name, password=None, active=True, confirm_token=None,
-                 title=u"", email=None, groups=()):
+                 title=u"", email=None, groups=None):
         self.name = name
         if password is not None:
             password = get_principals().hash_password(password)
@@ -86,6 +87,8 @@ class Principal(Base):
         self.confirm_token = confirm_token
         self.title = title
         self.email = email
+        if groups is None:
+            groups = []
         self.groups = groups
         self.creation_date = datetime.now()
         self.last_login_date = None

--- a/kotti/sqla.py
+++ b/kotti/sqla.py
@@ -146,6 +146,7 @@ for wrapper_class in (MutationDict, MutationList):
             ('pop', True),
             ('setdefault', True),
             ('update', True),
+            ('remove', True),
             ):
         setattr(
             wrapper_class, methodname,

--- a/kotti/tests/test_security_views.py
+++ b/kotti/tests/test_security_views.py
@@ -111,7 +111,7 @@ class TestUserDelete:
         with pytest.raises(KeyError):
             get_principals()[u'bob']
 
-    def test_deleted_group_removed_in_usergroups(self, events, extra_principals, root):
+    def test_deleted_group_removed_in_usergroups(self, events, extra_principals, root, db_session):
         from kotti.security import get_principals
         from kotti.views.users import user_delete
 
@@ -123,6 +123,7 @@ class TestUserDelete:
         request.params['name'] = u'group:bobsgroup'
         request.params['delete'] = u'delete'
         user_delete(root, request)
+        db_session.expire(bob)
         with pytest.raises(KeyError):
             get_principals()[u'group:bobsgroup']
         assert bob.groups == []


### PR DESCRIPTION
The user groups cleanup was not persisted. I updated the test to make it failed. And I updated the Column type of the principal.groups attribute.
