### PR TITLE
Move initialization of the blobstore provider from the provider's kotti_configure into Kotti itself

### DIFF
--- a/docs/developing/blobstorage.rst
+++ b/docs/developing/blobstorage.rst
@@ -13,18 +13,16 @@ These issues can be solved by chosing a different storage provider (available as
 Using an existing storage provider
 ----------------------------------
 
-To use an *external* storage provider, you usually need to add the add-on's ``kotti_configure`` to the list of configurators and specify the provider to be used (optionally with configuration options for that provider) via the ``kotti.blobstore`` setting in your ``*.ini`` file(s)::
+To use an *external* storage provider, you only need to specify the provider to be used (optionally with configuration options for that provider) via the ``kotti.blobstore`` setting in your ``*.ini`` file(s)::
 
   [app:main]
   use = egg:kotti
-  kotti.configurators =
-      kotti_filestore.kotti_configure
   kotti.blobstore = kotti_filestore.filestore://%(here)s/filestore
   ...
 
 The value passed to the ``kotti.blobstore`` setting is an URL.
 The scheme part (everything before ``://``) is the dotted path of the class which implements the provider.
-The path is passed to the provider upon its initialization and is usually used to pass configuration options to the provider.
+A parsed URL object (see https://pypi.python.org/pypi/YURL) is passed to the provider upon its initialization and is usually used to supply configuration options to the provider.
 In the example above the path is the absolute path of the filesystem directory where ``kotti_blobstore`` should store the BLOBs.
 
 Implementing your own storage provider

--- a/kotti/__init__.py
+++ b/kotti/__init__.py
@@ -16,6 +16,7 @@ from pyramid.events import BeforeRender
 from pyramid.threadlocal import get_current_registry
 from pyramid.util import DottedNameResolver
 from pyramid_beaker import session_factory_from_settings
+from yurl import URL
 
 from kotti.sqla import Base as KottiBase
 
@@ -172,6 +173,24 @@ def main(global_config, **settings):
     return config.make_wsgi_app()
 
 
+def configure_blobstore(settings):
+
+    if settings['kotti.blobstore'] == 'db':
+        return
+
+    # Parse the ``kotti.blobstore`` option as an URL.
+    url = URL(settings['kotti.blobstore']).decode()
+
+    # The scheme / protocol part of the URL is the dotted class name of the
+    # BlobStorage provider.
+    factory = DottedNameResolver(None).resolve(url.scheme)
+
+    # Create an instance of the provider, passing it the path and query parts
+    # of the URL as its configuration and store the instance in the settings
+    # dict.
+    settings['kotti.blobstore'] = factory(url)
+
+
 def base_configure(global_config, **settings):
     # Resolve dotted names in settings, include plug-ins and create a
     # Configurator.
@@ -206,6 +225,9 @@ def base_configure(global_config, **settings):
                 settings.setdefault(new, '')
                 settings[new] += ' ' + settings[old]
             del settings[old]
+
+    # Configure the BLOB storage
+    configure_blobstore(settings)
 
     _resolve_dotted(settings)
     secret1 = settings['kotti.secret']

--- a/kotti/interfaces.py
+++ b/kotti/interfaces.py
@@ -59,26 +59,28 @@ class IBlobStorage(Interface):
 
         The provider lookup is performed by a "dotted name lookup" from the
         protocol part of the URL in the ``kotti.filestorage`` option.  The
-        provider's configuration is taken from the path segment of that URL.
+        provider will be passed the complete URL upon initialization.  This
+        can be used by implementations for their configuration
 
         For example::
 
                 kotti.filestorage = kotti_filestore.filestore:///var/files
 
         will cause ``kotti_filestore.filestore`` to be instanciated with
-        ``/var/files`` being passed as its ``config`` upon initialization.
+        ``kotti_filestore.filestore:///var/files`` being passed as the URL upon
+        initialization.
 
         Because this option is parsed as an URL, your class name must be all
         lower case (scheme part of URLs is not case sensitive).
 
         See the ``kotti_filestore`` package's documentation for an example. """
 
-    def __init__(config):
-        """ The constructor is (optionally) passed a string containing the
+    def __init__(url):
+        """ The constructor is passed an already parsed URL containing the
         desired configuration options (see above).
 
-        :param config: Configuration string
-        :type config: str
+        :param url: URL from the PasteDeploy config file
+        :type url: :class:`yurl.URL`
         """
 
     def read(id):

--- a/kotti/tests/test_blobstore.py
+++ b/kotti/tests/test_blobstore.py
@@ -14,8 +14,8 @@ class DummyBlobstore(object):
     implements(IBlobStorage)
     _data = {}
 
-    def __init__(self, config):
-        self.config = config
+    def __init__(self, url):
+        self.url = url
 
     def read(self, id):
         return self._data[id]
@@ -141,3 +141,34 @@ def test_blobstore_events(dummy_blobstore, blobstore_settings,
             assert File.query.count() == 0
 
             assert id not in dummy_blobstore._data
+
+
+def test_configure_blobstore_db():
+
+    from kotti import configure_blobstore
+    settings = {'kotti.blobstore': 'db'}
+    configure_blobstore(settings)
+    assert settings['kotti.blobstore'] == 'db'
+
+
+# needed for the next test - scheme part of URLs is always case insensitive
+dummyblobstore = DummyBlobstore
+
+
+def test_configure_blobstore_dummy():
+
+    from kotti import configure_blobstore
+    url = 'kotti.tests.test_blobstore.dummyblobstore://' \
+          'username:password@host:1234/path?foo=bar&baz=f%20oo#fragment'
+
+    settings = {'kotti.blobstore': url}
+    configure_blobstore(settings)
+    blobstore = settings['kotti.blobstore']
+    assert type(blobstore) == DummyBlobstore
+    assert blobstore.url.scheme == 'kotti.tests.test_blobstore.dummyblobstore'
+    assert blobstore.url.userinfo == u'username:password'
+    assert blobstore.url.host == u'host'
+    assert blobstore.url.port == '1234'
+    assert blobstore.url.path == u'/path'
+    assert blobstore.url.query == u'foo=bar&baz=f oo'
+    assert blobstore.url.fragment == u'fragment'

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,6 +62,7 @@ waitress==0.8.5
 wsgiref==0.1.2
 xlrd==0.9.2
 xlwt==0.7.5
+YURL==0.12
 zope.component==4.1.0
 zope.configuration==4.0.2
 zope.deprecation==4.1.1

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ install_requires = [
     'transaction>=1.1.0',
     'unidecode',
     'waitress',
+    'YURL',
     'zope.deprecation',
     'zope.sqlalchemy',
     ]


### PR DESCRIPTION
This eliminates the need to implement the same generic code in every provider over and over again.  It also allows to configure the blobstore with a single option only.  Update documentation accordingly.  Add YURL as a dependency / requirement.
