### PR TITLE
Fix image URLs in @@contents view

### DIFF
--- a/kotti/templates/edit/contents.pt
+++ b/kotti/templates/edit/contents.pt
@@ -54,9 +54,9 @@
                     ${child.title}
                 </a>
                 <br tal:condition="child.type_info.name == 'Image'" />
-                <img src="${request.resource_url(child, 'image/span1')}"
+                <img src="${request.resource_url(child, 'image', 'span1')}"
                   class="thumb" title="${child.title}"
-                  data-content="&lt;img src='${request.resource_url(child, 'image/span4')}' /&gt;"
+                  data-content="&lt;img src='${request.resource_url(child, 'image', 'span4')}' /&gt;"
                   tal:condition="child.type_info.name == 'Image'" />
               </td>
               <td>


### PR DESCRIPTION
According to [documentation](http://docs.pylonsproject.org/docs/pyramid/en/latest/api/request.html#pyramid.request.Request.resource_url), `request.resource_url()` accepts subpath as positional arguments.
