### PR TITLE
Get config value of kotti.url_normalizer.map_non_ascii_characters as bool

### DIFF
--- a/kotti/url_normalizer.py
+++ b/kotti/url_normalizer.py
@@ -1,6 +1,8 @@
 import re
 from unidecode import unidecode
 
+from pyramid.settings import asbool
+
 from kotti import get_settings
 
 
@@ -34,7 +36,7 @@ def crop_name(base, maxLength=MAX_LENGTH):
 def url_normalizer(text, locale=None, max_length=MAX_URL_LENGTH):
 
     key = 'kotti.url_normalizer.map_non_ascii_characters'
-    map_non_ascii = get_settings()[key]
+    map_non_ascii = asbool(get_settings()[key])
     if map_non_ascii:
         text = unidecode(text)
 


### PR DESCRIPTION
AFAIK configuration files (i.e. app.ini) provide `kotti.url_normalier.map_non_ascii_character` as a string value, I think we should cast its value to a bool value when we access it.
