### PR TITLE
Action buttons with btn-default

### DIFF
--- a/kotti/util.py
+++ b/kotti/util.py
@@ -181,7 +181,8 @@ class Link(LinkBase):
 
 
 class ActionButton(Link):
-    def __init__(self, path, title=None, no_children=False, css_class=u"btn"):
+    def __init__(self, path, title=None, no_children=False,
+                 css_class=u"btn btn-default"):
         super(ActionButton, self).__init__(path, title)
         self.no_children = no_children
         self.css_class = css_class


### PR DESCRIPTION
Action buttons have `btn btn-default` as default `css_class`, not just `btn`.
