### PR TITLE
Update Installation docs to match the tutorial.

### DIFF
--- a/docs/first_steps/installation.rst
+++ b/docs/first_steps/installation.rst
@@ -20,10 +20,10 @@ It is recommended to install Kotti inside a virtualenv:
 
   virtualenv mysite
   cd mysite
-  bin/pip install -r https://raw.github.com/Kotti/Kotti/|version|/requirements.txt
-  bin/pip install Kotti==|version|
+  bin/pip install -r https://raw.github.com/Kotti/Kotti/master/requirements.txt
+  bin/pip install git+https://github.com/Kotti/Kotti.git
 
-This will install Kotti |version| and all its requirements into your
+This will install the latest version of Kotti and all its requirements into your
 virtualenv.
 
 Kotti uses `Paste Deploy`_ for configuration and deployment.  An
@@ -32,7 +32,7 @@ distribution.  Download it to your virtualenv directory (mysite):
 
 .. parsed-literal::
 
-  wget https://github.com/Kotti/Kotti/raw/|version|/app.ini
+  wget https://raw.github.com/Kotti/Kotti/master/app.ini
 
 See the list of `Kotti tags`_, perhaps to find the latest released
 version. You can search the `Kotti listing on PyPI`_ also, for the


### PR DESCRIPTION
Hey Disko,

This branch removes your |version| variable in the Installation docs, and uses the github master branch instead. This allows someone to follow the Installation and Tutorial together.

I'm not sure if you want/need this right now. We need to figure out what to do long-term though.

Do with it what you wish :)

Mike
