### PR TITLE
paster template is kotti, not kotti_addon

### DIFF
--- a/docs/first_steps/tut-1.rst
+++ b/docs/first_steps/tut-1.rst
@@ -37,7 +37,7 @@ With ``kotti_paster`` installed, we can now create the skeleton for the add-on p
 
 .. code-block:: bash
 
-  bin/paster create -t kotti_addon kotti_mysite
+  bin/paster create -t kotti kotti_mysite
 
 Running this command, it will ask us a number of questions.
 Hit enter for every question to accept the defaults.


### PR DESCRIPTION
Fixed an error in the tutorial with the paster template name. I had kotti_addon, it should be kotti.
