### PR TITLE
Filedepot: store file data as storage-configured blobs

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -28,7 +28,7 @@ pipeline =
 
 [server:main]
 use = egg:waitress#main
-host = 0.0.0.0
+host = 127.0.0.1
 port = 5000
 
 [alembic]

--- a/development.ini
+++ b/development.ini
@@ -28,7 +28,7 @@ pipeline =
 
 [server:main]
 use = egg:waitress#main
-host = 127.0.0.1
+host = 0.0.0.0
 port = 5000
 
 [alembic]

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -17,6 +17,7 @@ API Documentation
    kotti.populate
    kotti.request
    kotti.resources
+   kotti.filedepot
    kotti.security
    kotti.sqla
    kotti.testing

--- a/docs/api/kotti.filedepot.rst
+++ b/docs/api/kotti.filedepot.rst
@@ -1,0 +1,7 @@
+.. _api-kotti.filedepot:
+
+kotti.filedepot
+---------------
+
+.. automodule:: kotti.filedepot
+   :members:

--- a/docs/developing/advanced/blobs.rst
+++ b/docs/developing/advanced/blobs.rst
@@ -4,14 +4,14 @@ Working with blob data in Kotti
 ===============================
 
 Kotti provides a flexible mechanism of storing blob data by with the help of
-:app:`filedepot`_ storages. Both ``File`` and ``Image`` store their data in
+`filedepot`_ storages. Both ``File`` and ``Image`` store their data in
 :class:`depot.fields.sqlalchemy.UploadedFileField` and they will offload their
 blob data to the configured depot storage. Working together with
-:app:`filedepot` configured storages means it is possible to store blob data in
+`filedepot`_ configured storages means it is possible to store blob data in
 a variety of ways: filesystem, GridFS, Amazon storage, etc. 
 
-By default :app:`Kotti` will store its blob data in the configured SQL
-database, using :class:``~kotti.filedepot.DBFileStorage`` storage, but you can
+By default Kotti will store its blob data in the configured SQL
+database, using :class:`kotti.filedepot.DBFileStorage` storage, but you can
 configure your own preferred way of storing your blob data. The benefit of
 storing files in ``DBFileStorage`` is having *all* content in a single place
 (the DB) which makes backups, exporting and importing of your site's data easy,
@@ -23,21 +23,21 @@ handled efficiently.
 Configuring a depot store
 -------------------------
 
-While :app:`filedepot` allows storing data in any of the configured
+While `filedepot`_ allows storing data in any of the configured
 filestorages, at this time there's no mechanism in Kotti to select, at runtime,
-the depot where new data will be saved. Instead, :app:`Kotti` will store new
-files only in the configured *default* store. If, for example, you add a new
+the depot where new data will be saved. Instead, Kotti will store new
+files only in the configured ``default`` store. If, for example, you add a new
 depot and make that the default, you should leave the old depot configured so
-that :app:`Kotti` will continue serving files uploaded there.
+that Kotti will continue serving files uploaded there.
 
-By default, `Kotti` comes configured with a db-based filestorage.::
+By default, Kotti comes configured with a db-based filestorage.::
 
     kotti.depot.0.name = dbfiles
     kotti.depot.0.backend = kotti.filedepot.DBFileStorage
 
 The depot configured at position 0 is the default file depot. The minimum
 information required to configure a depot are the ``name`` and ``backend``. The
-``name`` can be any string and it is used by :app:`filedepot` to identify the
+``name`` can be any string and it is used by `filedepot`_ to identify the
 depot store for a particular saved file. The ``name`` should never be changed, as
 it will make the saved files unaccessible.
 
@@ -68,7 +68,7 @@ Adding a blob data attribute to your models can be as simple as::
 
 While you can directly assign a ``bytes`` value to the ``avatar`` column, the
 ``UploadedFileField`` column type works best when you assign a
-:class:``cgi.FieldStorage`` instance as value.::
+:class:`cgi.FieldStorage` instance as value::
 
     from StringIO import StringIO
     from kotti.util import _to_fieldstorage
@@ -84,9 +84,9 @@ While you can directly assign a ``bytes`` value to the ``avatar`` column, the
     person.avatar = _to_fieldstorage(**data)
 
 Note that the ``data`` dictionary described here has the same format as the
-deserialized value of a ``deform.widget.FileUploadWidget``. See the
-:class:`~kotti.views.edit.content.FileAddForm` and 
-:class:`~kotti.views.edit.content.FileEditForm` for a full example
+deserialized value of a ``deform.widget.FileUploadWidget``. See
+:class:`kotti.views.edit.content.FileAddForm` and 
+:class:`kotti.views.edit.content.FileEditForm` for a full example
 of how to add or edit a model with a blob field.
 
 Reading blob data
@@ -108,12 +108,12 @@ Downloading blob data
 ---------------------
 
 Serving blob data is facilitated by the
-:class:``~kotti.views.file.UploadedFileResponse``. You should return an
+:class:`kotti.views.file.UploadedFileResponse`. You should return an
 instance of this class as the response of your view, and it will stream the
 blob from the storage to the client browser. As parameters it takes the blob
 column and the type of disposition: ``inline`` or ``attachment`` (to trigger a
 download in the browser). This, for example is the ``inline-view`` view for a
-:class:``~kotti.resources.File``::
+:class:`kotti.resources.File`::
 
     @view_config(name='inline-view', context=File, permission='view')
     def inline_view(context, request):
@@ -126,7 +126,7 @@ location.
 Testing UploadedFileField columns
 ---------------------------------
 
-Because :class:``depot.manager.DepotManager`` acts as a singleton, special care
+Because :class:`depot.manager.DepotManager` acts as a singleton, special care
 needs to be taken when testing features that involve saving data into
 ``UploadedFileField`` columns.
 
@@ -171,7 +171,7 @@ only. You can invoke the script with::
 The storage names are those assigned in the configuration file designated in
 ``<config_uri>``. For example, let's assume you've started a website that has
 the default blob storage, the ``DBFileStorage`` named *dbfiles*. You'd like to
-move all the existing blob data to a :class:``depot.io.local.LocalFileStorage``
+move all the existing blob data to a :class:`depot.io.local.LocalFileStorage`
 storage and make that the default. First, add the ``LocalFileStorage`` depot, 
 make it the default and place the old ``DBFileStorage`` in position *1*:::
 

--- a/docs/developing/advanced/blobs.rst
+++ b/docs/developing/advanced/blobs.rst
@@ -1,4 +1,4 @@
-.. _blobs
+.. _blobs:
 
 Working with blob data in Kotti
 ===============================

--- a/docs/developing/advanced/blobs.rst
+++ b/docs/developing/advanced/blobs.rst
@@ -74,7 +74,7 @@ While you can directly assign a ``bytes`` value to the ``avatar`` column, the
             'size': len(content),
             }
     person = Person()
-    person.avatar = _to_fielstorage(**data)
+    person.avatar = _to_fieldstorage(**data)
 
 Note that the ``data`` dictionary described here has the same format as the
 deserialized value of a ``deform.widget.FileUploadWidget``. See the
@@ -123,11 +123,11 @@ Because :class:``depot.manager.DepotManager`` acts as a singleton, special care
 needs to be taken when testing features that involve saving data into
 ``UploadedFileField`` columns.
 
-``UploadedFileField`` columns always require having at least one depot file
-storage configured. You can use a fixture called ``filedepot`` to have a mock
-file storage available for your tests.
+``UploadedFileField`` columns require having at least one depot file storage
+configured. You can use a fixture called ``filedepot`` to have a mock file
+storage available for your tests.
 
-If you're developing new file depot storages you should use the
+If you're developing new depot file storages you should use the
 ``no_filedepots`` fixture, which resets the configured depots for the test run
 and restores the default depots back, as a teardown.
 

--- a/docs/developing/advanced/blobs.rst
+++ b/docs/developing/advanced/blobs.rst
@@ -119,11 +119,17 @@ location.
 Testing UploadedFileField columns
 ---------------------------------
 
-Because :class:``depot.manager.DepotManager`` acts as a singleton, special care needs to be taken when testing features that involve saving data into ``UploadedFileField`` columns.
+Because :class:``depot.manager.DepotManager`` acts as a singleton, special care
+needs to be taken when testing features that involve saving data into
+``UploadedFileField`` columns.
 
-``UploadedFileField`` columns always require having at least one depot file storage configured. You can use a fixture called ``filedepot`` to have a mock file storage available for your tests.
+``UploadedFileField`` columns always require having at least one depot file
+storage configured. You can use a fixture called ``filedepot`` to have a mock
+file storage available for your tests.
 
-If you're developing new file depot storages you should use the ``no_filedepots`` fixture, which resets the configured depots for the test run and restores the default depots back, as a teardown.
+If you're developing new file depot storages you should use the
+``no_filedepots`` fixture, which resets the configured depots for the test run
+and restores the default depots back, as a teardown.
 
 Inheritance issues with UploadedFileField columns
 -------------------------------------------------

--- a/docs/developing/advanced/blobs.rst
+++ b/docs/developing/advanced/blobs.rst
@@ -120,9 +120,19 @@ Inheritance issues with UploadedFileField columns
 -------------------------------------------------
 
 You should be aware that, presently, subclassing a model with an
-``UploadedFileField`` column doesn't work properly.  As a workaround, look how
-we solve the problem using a ``__declare_last__`` classmethod in
-:meth:`~kotti.resources.File.__declare_last__`, which will solve the problem
-for the :class:`kotti.resources.Image` subclass.
+``UploadedFileField`` column doesn't work properly.  As a workaround, add a 
+``__declare_last__`` classmethod in your superclass model, similar to the one
+below, where we're fixing the ``data`` column of the ``File`` class. ::
+
+    from depot.fields.sqlalchemy import _SQLAMutationTracker
+
+    class File(Content):
+
+        data = UploadedFileField()
+
+        @classmethod
+        def __declare_last__(cls):
+            event.listen(cls.data, 'set', _SQLAMutationTracker._field_set, retval=True)
+
 
 .. _filedepot: https://pypi.python.org/pypi/filedepot/

--- a/docs/developing/advanced/blobs.rst
+++ b/docs/developing/advanced/blobs.rst
@@ -1,0 +1,124 @@
+.. _blobs
+
+Working with blob data in Kotti
+===============================
+
+Kotti provides a flexible mechanism of storing blob data by with the help of
+:app:`filedepot`_ storages. Both ``File`` and ``Image`` store their data in
+:class:`depot.fields.sqlalchemy.UploadedFileField` and they will offload their
+blob data to the configured depot storage. Working together with
+:app:`filedepot` configured storages means it is possible to store blob data in
+a variety of ways: filesystem, GridFS, Amazon storage, etc. By default
+:app:`Kotti` will store its blob data in the configured SQL database, using
+``~kotti.filedepot.DBFileStorage`` storage, but you can configure your own
+preferred way of storing your blob data.
+
+Configuring a depot store
+-------------------------
+
+While :app:`filedepot` allows storing data in any of the configured
+filestorages, at this time there's no mechanism in Kotti to select, at runtime,
+the depot where new data will be saved. Instead, :app:`Kotti` will store new
+files only in the configured *default* store. If, for example, you add a new
+depot and make that the default, you should leave the old depot configured so
+that :app:`Kotti` will continue serving files uploaded there.
+
+By default, `Kotti` comes configured with a db-based filestorage.::
+
+    kotti.depot.0.name = dbfiles
+    kotti.depot.0.backend = kotti.filedepot.DBFileStorage
+
+The depot configured at position 0 is the default file depot. The minimum
+information required to configure a depot are the `name` and `backend`. The
+`name` can be any string and it is used by :app:`filedepot` to identify the
+depot store for a particular saved file. The `name` should never be changed, as
+it will make the saved files unaccessible. 
+
+Any further parameters for a particular backend will be passed as keyword
+arguments to the backend class. See this example, in which we store, by
+default, files in `/var/local/files/` using the
+:class:`depot.io.local.LocalFileStorage`::
+
+    kotti.depot.0.name = localfs
+    kotti.depot.0.backend = depot.io.local.LocalFileStorage
+    kotti.depot.0.storage_path = /var/local/files
+    kotti.depot.1.name = dbfiles
+    kotti.depot.1.backend = kotti.filedepot.DBFileStorage
+
+Notice that we kept the `dbfiles` storage, but we moved it to position 1. No
+blob data will be saved anymore, but existing files in that storage will
+continue to be served from there.
+
+Add a blob field to your model
+------------------------------
+Adding a blob data attribute to your can be as simple as::
+
+    from depot.fields.sqlalchemy import UploadedFileField
+    from kotti.resources import Content
+
+    class Person(Content):
+        avatar = UploadedFileField()
+
+While you can directly assign a `bytes` value to the `avatar` column, the
+``UploadedFileField`` column type works best when you assign a
+:class:``cgi.FieldStorage`` instance as value.::
+
+    from StringIO import StringIO
+    from kotti.util import _to_fieldstorage
+
+    content = '...'
+    data = {
+            'fp': StringIO(content),
+            'filename': 'avatar.png', 
+            'mimetype': 'image/png',
+            'size': len(content),
+            }
+    person = Person()
+    person.avatar = _to_fielstorage(**data)
+
+Note that the ``data`` dictionary described here has the same format as the
+deserialized value of a ``deform.widget.FileUploadWidget``. See the
+:class:`~kotti.views.edit.content.FileAddForm` and 
+:class:`~kotti.views.edit.content.FileEditForm` for a full example
+of how to add or edit a model with a blob field.
+
+Reading blob data
+-----------------
+
+If you try directly to read data from an `UploadedFileField` you'll get a
+:class:`depot.fields.upload.UploadedFile` instance, which offers a
+dictionary-like interface to the stored file metadata and direct access to a
+stream with the stored file through the ``file`` attribute::
+
+    person = DBSession.query(Person).get(1)
+    blob = person.avatar.file.read()
+
+You should never write to the file stream directly. Instead, you should assign
+a new value to the ``UploadedFileField`` column, as described in the previous
+section.
+
+Downloading blob data
+---------------------
+
+Serving blob data is facilitated by the
+:class:``~kotti.views.file.UploadedFileResponse``. You should return an
+instance of this class as the response of your view, and it will stream the
+blob from the storage to the client browser. As parameters it takes the blob
+column and the type of disposition: ``inline`` or ``attachment`` (to trigger a
+download in the browser). This, for example is the ``inline-view`` view for a
+:class:``~kotti.resources.File``::
+
+    @view_config(name='inline-view', context=File, permission='view')
+    def inline_view(context, request):
+        return UploadedFileResponse(context.data, request, disposition='inline')
+
+If the used depot storage offers a ``public_url`` value for the blob, then
+``UploadedFileResponse``, instead of streaming the data, will redirect instead
+to that location.
+
+Inheritance issues with UploadedFileField columns
+-------------------------------------------------
+
+You should be aware that, presently, inheriting the ``UploadedFileField`` column doesn't work properly. For a solution to this problem, look how we solve the problem using :meth:`~kotti.resources.File.__declare_last__`, which will solve the problem for the :class:`kotti.resources.Image` subclass.
+
+.. _filedepot: https://pypi.python.org/pypi/filedepot/

--- a/docs/developing/advanced/blobs.rst
+++ b/docs/developing/advanced/blobs.rst
@@ -10,7 +10,7 @@ blob data to the configured depot storage. Working together with
 :app:`filedepot` configured storages means it is possible to store blob data in
 a variety of ways: filesystem, GridFS, Amazon storage, etc. By default
 :app:`Kotti` will store its blob data in the configured SQL database, using
-``~kotti.filedepot.DBFileStorage`` storage, but you can configure your own
+:class:``~kotti.filedepot.DBFileStorage`` storage, but you can configure your own
 preferred way of storing your blob data.
 
 Configuring a depot store
@@ -29,14 +29,14 @@ By default, `Kotti` comes configured with a db-based filestorage.::
     kotti.depot.0.backend = kotti.filedepot.DBFileStorage
 
 The depot configured at position 0 is the default file depot. The minimum
-information required to configure a depot are the `name` and `backend`. The
-`name` can be any string and it is used by :app:`filedepot` to identify the
-depot store for a particular saved file. The `name` should never be changed, as
-it will make the saved files unaccessible. 
+information required to configure a depot are the ``name`` and ``backend``. The
+``name`` can be any string and it is used by :app:`filedepot` to identify the
+depot store for a particular saved file. The ``name`` should never be changed, as
+it will make the saved files unaccessible.
 
 Any further parameters for a particular backend will be passed as keyword
 arguments to the backend class. See this example, in which we store, by
-default, files in `/var/local/files/` using the
+default, files in ``/var/local/files/`` using the
 :class:`depot.io.local.LocalFileStorage`::
 
     kotti.depot.0.name = localfs
@@ -45,13 +45,13 @@ default, files in `/var/local/files/` using the
     kotti.depot.1.name = dbfiles
     kotti.depot.1.backend = kotti.filedepot.DBFileStorage
 
-Notice that we kept the `dbfiles` storage, but we moved it to position 1. No
-blob data will be saved anymore, but existing files in that storage will
-continue to be served from there.
+Notice that we kept the ``dbfiles`` storage, but we moved it to position 1. No
+blob data will be saved there anymore, but existing files in that storage will
+continue to be available from there.
 
 Add a blob field to your model
 ------------------------------
-Adding a blob data attribute to your can be as simple as::
+Adding a blob data attribute to your models can be as simple as::
 
     from depot.fields.sqlalchemy import UploadedFileField
     from kotti.resources import Content
@@ -59,7 +59,7 @@ Adding a blob data attribute to your can be as simple as::
     class Person(Content):
         avatar = UploadedFileField()
 
-While you can directly assign a `bytes` value to the `avatar` column, the
+While you can directly assign a ``bytes`` value to the ``avatar`` column, the
 ``UploadedFileField`` column type works best when you assign a
 :class:``cgi.FieldStorage`` instance as value.::
 
@@ -85,7 +85,7 @@ of how to add or edit a model with a blob field.
 Reading blob data
 -----------------
 
-If you try directly to read data from an `UploadedFileField` you'll get a
+If you try directly to read data from an ``UploadedFileField`` you'll get a
 :class:`depot.fields.upload.UploadedFile` instance, which offers a
 dictionary-like interface to the stored file metadata and direct access to a
 stream with the stored file through the ``file`` attribute::
@@ -113,12 +113,16 @@ download in the browser). This, for example is the ``inline-view`` view for a
         return UploadedFileResponse(context.data, request, disposition='inline')
 
 If the used depot storage offers a ``public_url`` value for the blob, then
-``UploadedFileResponse``, instead of streaming the data, will redirect instead
-to that location.
+``UploadedFileResponse``, instead of streaming the data, will redirect to that
+location.
 
 Inheritance issues with UploadedFileField columns
 -------------------------------------------------
 
-You should be aware that, presently, inheriting the ``UploadedFileField`` column doesn't work properly. For a solution to this problem, look how we solve the problem using :meth:`~kotti.resources.File.__declare_last__`, which will solve the problem for the :class:`kotti.resources.Image` subclass.
+You should be aware that, presently, subclassing a model with an
+``UploadedFileField`` column doesn't work properly.  As a workaround, look how
+we solve the problem using a ``__declare_last__`` classmethod in
+:meth:`~kotti.resources.File.__declare_last__`, which will solve the problem
+for the :class:`kotti.resources.Image` subclass.
 
 .. _filedepot: https://pypi.python.org/pypi/filedepot/

--- a/docs/developing/advanced/blobs.rst
+++ b/docs/developing/advanced/blobs.rst
@@ -116,6 +116,15 @@ If the used depot storage offers a ``public_url`` value for the blob, then
 ``UploadedFileResponse``, instead of streaming the data, will redirect to that
 location.
 
+Testing UploadedFileField columns
+---------------------------------
+
+Because :class:``depot.manager.DepotManager`` acts as a singleton, special care needs to be taken when testing features that involve saving data into ``UploadedFileField`` columns.
+
+``UploadedFileField`` columns always require having at least one depot file storage configured. You can use a fixture called ``filedepot`` to have a mock file storage available for your tests.
+
+If you're developing new file depot storages you should use the ``no_filedepots`` fixture, which resets the configured depots for the test run and restores the default depots back, as a teardown.
+
 Inheritance issues with UploadedFileField columns
 -------------------------------------------------
 

--- a/docs/developing/advanced/index.rst
+++ b/docs/developing/advanced/index.rst
@@ -12,5 +12,6 @@ Advanced Topics
     events
     frontpage-different-template
     images
+    blobs
     static-resource-management
     understanding-kotti-startup

--- a/docs/developing/basic/configuration.rst
+++ b/docs/developing/basic/configuration.rst
@@ -75,6 +75,8 @@ kotti.datetime_format         Datetime format to use, default: ``medium``
 kotti.time_format             Time format to use, default: ``medium``
 kotti.max_file_size           Max size for file uploads, default: ```10`` (MB)
 
+kotti.depot.*.*               Configure the blob storage. More details below
+
 pyramid.default_locale_name   Set the user interface language, default ``en``
 ============================  ==================================================
 
@@ -306,6 +308,54 @@ The default configuration here is:
   kotti.url_normalzier = kotti.url_normalizer.url_normalizer
   kotti.url_normalizer.map_non_ascii_characters = True
 
+
+Blob storage configuration
+--------------------------
+
+By default, Kotti will store blob data (files uploaded in File and Image
+instances) in the database. Internally, Kotti integrates with :app:`filedepot`,
+so it is possible to use any :app:``filedepot`` compatible storage, including those
+provided by :app:``filedepot`` itself:
+
+- :class:``depot.io.local.LocalFileStorage``
+- :class:``depot.io.awss3.S3Storage``
+- :class:``depot.io.gridfs.GridFSStorage``
+
+The default storage for :app:``Kotti`` is
+:class:``~kotti.filedepot.DBFileStorage``. The benefit of storing files in
+``DBFileStorage`` is having *all* content in a single place (the DB) which
+makes backups, exporting and importing of your site's data easy, as long as you
+don't have too many or too large files. The downsides of this approach appear
+when your database server resides on a different host (network performance
+becomes a greater issue) or your DB dumps become too large to be handled
+efficiently.
+
+To configure a depot, several ``kotti.depot.*.*`` lines need to be added. The
+number in the first position is used to group backend configuration and to
+order the file storages in the configuration of :app:``filedepot``.  The depot
+configured with number 0 will be the default depot, where all new blob data
+will be saved.  There are 2 options that are required for every storage
+configuration: ``name`` and ``backend``. The ``name`` is a unique string that
+will be used to identify the path of saved files (it is recorded with each blob
+info), so once configured for a particular storage, it should never change. The
+``backend`` should point to a dotted path for the storage class. Then, any
+number of keyword arguments can be added, and they will be passed to the
+backend class on initialization.
+
+Example of a possible configurationi that stores blob data on the disk, in
+``/var/local/files`` using the :app:``filedepot``
+:class:``depot.io.local.LocalFileStorage`` provided backend. Kotti's default
+backend, ``DBFileStorage`` has been moved to position **1** and all data stored
+there will continue to be available. See :ref:`blobs` to see how to migrate
+blob data between storages.
+
+.. code-block:: ini
+
+  kotti.depot.0.name = localfs
+  kotti.depot.0.backend = depot.io.local.LocalFileStorage
+  kotti.depot.0.storage_path = /var/local/files
+  kotti.depot.1.name = dbfiles
+  kotti.depot.1.backend = kotti.filedepot.DBFileStorage
 
 
 Local navigation

--- a/kotti/__init__.py
+++ b/kotti/__init__.py
@@ -25,6 +25,15 @@ Base.query = DBSession.query_property()
 TRUE_VALUES = ('1', 'y', 'yes', 't', 'true')
 FALSE_VALUES = ('0', 'n', 'no', 'f', 'false', 'none')
 
+#tibi temp
+from depot.manager import DepotManager
+# Configure a *default* depot to store files on MongoDB GridFS
+DepotManager.configure('default', {
+    'depot.backend': 'depot.io.local.LocalFileStorage',
+    'depot.storage_path': 'var/files'
+})
+#end tibi temp
+
 
 def authtkt_factory(**settings):
     from kotti.security import list_groups_callback

--- a/kotti/__init__.py
+++ b/kotti/__init__.py
@@ -101,8 +101,7 @@ conf_defaults = {
     'kotti.datetime_format': 'medium',
     'kotti.time_format': 'medium',
     'kotti.max_file_size': '10',
-    'kotti.depot.fs0.backend': 'depot.io.local.LocalFileStorage',
-    'kotti.depot.fs0.storage_path': 'var/files',
+    'kotti.depot.fs0.backend': 'kotti.filedepot.DBFileStorage',
     'kotti.fanstatic.edit_needed': 'kotti.fanstatic.edit_needed',
     'kotti.fanstatic.view_needed': 'kotti.fanstatic.view_needed',
     'kotti.static.edit_needed': '',  # BBB

--- a/kotti/__init__.py
+++ b/kotti/__init__.py
@@ -101,7 +101,8 @@ conf_defaults = {
     'kotti.datetime_format': 'medium',
     'kotti.time_format': 'medium',
     'kotti.max_file_size': '10',
-    'kotti.depot.fs0.backend': 'kotti.filedepot.DBFileStorage',
+    'kotti.depot.0.name': 'dbfiles',
+    'kotti.depot.0.backend': 'kotti.filedepot.DBFileStorage',
     'kotti.fanstatic.edit_needed': 'kotti.fanstatic.edit_needed',
     'kotti.fanstatic.view_needed': 'kotti.fanstatic.view_needed',
     'kotti.static.edit_needed': '',  # BBB

--- a/kotti/__init__.py
+++ b/kotti/__init__.py
@@ -25,14 +25,6 @@ Base.query = DBSession.query_property()
 TRUE_VALUES = ('1', 'y', 'yes', 't', 'true')
 FALSE_VALUES = ('0', 'n', 'no', 'f', 'false', 'none')
 
-# tibi temp
-from depot.manager import DepotManager
-DepotManager.configure('default', {
-    'depot.backend': 'depot.io.local.LocalFileStorage',
-    'depot.storage_path': 'var/files'
-})
-# end tibi temp
-
 
 def authtkt_factory(**settings):
     from kotti.security import list_groups_callback
@@ -67,6 +59,7 @@ conf_defaults = {
     'pyramid.includes': '',
     'kotti.base_includes': ' '.join([
         'kotti',
+        'kotti.filedepot',
         'kotti.events',
         'kotti.views',
         'kotti.views.cache',
@@ -108,6 +101,8 @@ conf_defaults = {
     'kotti.datetime_format': 'medium',
     'kotti.time_format': 'medium',
     'kotti.max_file_size': '10',
+    'kotti.depot.default.backend': 'depot.io.local.LocalFileStorage',
+    'kotti.depot.default.storage_path': 'var/files',
     'kotti.fanstatic.edit_needed': 'kotti.fanstatic.edit_needed',
     'kotti.fanstatic.view_needed': 'kotti.fanstatic.view_needed',
     'kotti.static.edit_needed': '',  # BBB

--- a/kotti/__init__.py
+++ b/kotti/__init__.py
@@ -101,8 +101,8 @@ conf_defaults = {
     'kotti.datetime_format': 'medium',
     'kotti.time_format': 'medium',
     'kotti.max_file_size': '10',
-    'kotti.depot.default.backend': 'depot.io.local.LocalFileStorage',
-    'kotti.depot.default.storage_path': 'var/files',
+    'kotti.depot.fs0.backend': 'depot.io.local.LocalFileStorage',
+    'kotti.depot.fs0.storage_path': 'var/files',
     'kotti.fanstatic.edit_needed': 'kotti.fanstatic.edit_needed',
     'kotti.fanstatic.view_needed': 'kotti.fanstatic.view_needed',
     'kotti.static.edit_needed': '',  # BBB

--- a/kotti/__init__.py
+++ b/kotti/__init__.py
@@ -25,14 +25,13 @@ Base.query = DBSession.query_property()
 TRUE_VALUES = ('1', 'y', 'yes', 't', 'true')
 FALSE_VALUES = ('0', 'n', 'no', 'f', 'false', 'none')
 
-#tibi temp
+# tibi temp
 from depot.manager import DepotManager
-# Configure a *default* depot to store files on MongoDB GridFS
 DepotManager.configure('default', {
     'depot.backend': 'depot.io.local.LocalFileStorage',
     'depot.storage_path': 'var/files'
 })
-#end tibi temp
+# end tibi temp
 
 
 def authtkt_factory(**settings):

--- a/kotti/alembic/versions/413fa5fcc581_add_filedepot.py
+++ b/kotti/alembic/versions/413fa5fcc581_add_filedepot.py
@@ -40,8 +40,8 @@ def upgrade():
         stored_file.last_modified = obj.modification_date
         obj.data = uploaded_file.encode()
 
-        log.info("Migrated {} bytes for File with pk {} to {}/{}".
-                    format(len(obj.data), obj.id, dn, uploaded_file['file_id']))
+        log.info("Migrated {} bytes for File with pk {} to {}/{}".format(
+            len(obj.data), obj.id, dn, uploaded_file['file_id']))
 
     DBSession.flush()
     if DBSession.get_bind().name != 'sqlite':   # not supported by sqlite

--- a/kotti/alembic/versions/413fa5fcc581_add_filedepot.py
+++ b/kotti/alembic/versions/413fa5fcc581_add_filedepot.py
@@ -12,6 +12,7 @@ down_revision = '1063d7178fa'
 
 import logging
 import sqlalchemy as sa
+from alembic import op
 
 log = logging.getLogger('kotti')
 
@@ -21,6 +22,7 @@ def upgrade():
 
     from depot.manager import DepotManager
     from depot.fields.upload import UploadedFile
+    from depot.fields.sqlalchemy import UploadedFileField
 
     from kotti import DBSession, metadata
     from kotti.resources import File
@@ -40,6 +42,11 @@ def upgrade():
 
         log.info("Migrated {} bytes for File with pk {} to {}/{}".
                     format(len(obj.data), obj.id, dn, uploaded_file['file_id']))
+
+    DBSession.flush()
+    if DBSession.get_bind().name != 'sqlite':   # not supported by sqlite
+        op.alter_column('files', 'data', type_=UploadedFileField())
+
 
 def downgrade():
     pass

--- a/kotti/alembic/versions/413fa5fcc581_add_filedepot.py
+++ b/kotti/alembic/versions/413fa5fcc581_add_filedepot.py
@@ -8,7 +8,7 @@ Create Date: 2014-12-07 05:10:04.294222
 
 # revision identifiers, used by Alembic.
 revision = '413fa5fcc581'
-down_revision = '1063d7178fa'
+down_revision = '559ce6eb0949'
 
 import logging
 import sqlalchemy as sa

--- a/kotti/alembic/versions/413fa5fcc581_add_filedepot.py
+++ b/kotti/alembic/versions/413fa5fcc581_add_filedepot.py
@@ -1,0 +1,50 @@
+"""Migrate binary file storage to filedepot
+
+Revision ID: 413fa5fcc581
+Revises: 1063d7178fa
+Create Date: 2014-12-07 05:10:04.294222
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '413fa5fcc581'
+down_revision = '1063d7178fa'
+
+#from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    sa.orm.events.MapperEvents._clear() # avoids filedepot magic
+
+    from depot.manager import DepotManager
+    from depot.fields.upload import UploadedFile
+
+    from kotti import DBSession, metadata
+    from kotti.resources import File
+
+    t = sa.Table('files', metadata)
+    t.c.data.type = sa.LargeBinary()
+
+    class UF(UploadedFile):
+        _frozen = False
+
+        def __init__(self):
+            self.depot_name = DepotManager.get_default()
+            self.files = []
+
+    for o in DBSession.query(File):
+        print o.id, len(o.data), o.filename, o.mimetype, o.modification_date
+
+        s = UF()
+        s.process_content(o.data, filename=o.filename, content_type=o.mimetype)
+        f = DepotManager.get().get(s['file_id'])
+        f.last_modified = o.modification_date   # not ok for LocalStore
+        o.data = s.encode()
+
+    DBSession.flush()
+    raise ValueError
+
+
+def downgrade():
+    pass

--- a/kotti/alembic/versions/413fa5fcc581_add_filedepot.py
+++ b/kotti/alembic/versions/413fa5fcc581_add_filedepot.py
@@ -37,8 +37,8 @@ def upgrade():
         uploaded_file.process_content(
             obj.data, filename=obj.filename, content_type=obj.mimetype)
         stored_file = DepotManager.get().get(uploaded_file['file_id'])
-        stored_file.last_modified = obj.modification_date
         obj.data = uploaded_file.encode()
+        stored_file.last_modified = obj.modification_date
 
         log.info("Migrated {} bytes for File with pk {} to {}/{}".format(
             len(obj.data), obj.id, dn, uploaded_file['file_id']))

--- a/kotti/filedepot.py
+++ b/kotti/filedepot.py
@@ -136,10 +136,6 @@ class DBStoredFile(Base):
 
     @classmethod
     def __declare_last__(cls):
-        # For the ``data`` column, use the field value setter from filedepot.
-        # filedepot already registers this event listener, but it does so in a
-        # way that won't work properly for subclasses of File
-
         event.listen(DBStoredFile.data, 'set', DBStoredFile.refresh_data)
 
 

--- a/kotti/filedepot.py
+++ b/kotti/filedepot.py
@@ -1,0 +1,178 @@
+from datetime import datetime
+from depot.io.interfaces import StoredFile, FileStorage
+
+from sqlalchemy import Column
+from sqlalchemy import DateTime
+from sqlalchemy import Integer
+from sqlalchemy import LargeBinary
+from sqlalchemy import String
+from sqlalchemy import Unicode
+from sqlalchemy.orm import deferred
+
+from kotti import Base
+from kotti import DBSession
+
+import uuid
+
+class CooperativeMeta(type):
+    def __new__(cls, name, bases, members):
+        # collect up the metaclasses
+        metas = [type(base) for base in bases]
+
+        # prune repeated or conflicting entries
+        metas = [meta for index, meta in enumerate(metas)
+            if not [later for later in metas[index + 1:]
+                if issubclass(later, meta)]]
+
+        # whip up the actual combined meta class derive off all of these
+        meta = type(name, tuple(metas), dict(combined_metas=metas))
+
+        # make the actual object
+        return meta(name, bases, members)
+
+    def __init__(self, name, bases, members):
+        for meta in self.combined_metas:
+            meta.__init__(self, name, bases, members)
+
+
+class DBStoredFile(Base, StoredFile):
+    """depotfile StoredFile implementation that stores data in the db.
+
+    Can be used together with DBFileStorage to implement blobs (large files)
+    storage in the database.
+    """
+
+    __tablename__ = "blobs"
+    __metaclass__ = CooperativeMeta
+
+    #: Primary key column in the DB
+    #: (:class:`sqlalchemy.types.Integer`)
+    id = Column(Integer(), primary_key=True)
+    #: Unique id given to this blob
+    #: (:class:`sqlalchemy.types.String`)
+    file_id = Column(String(36), index=True)
+    #: The original filename it had when it was uploaded.
+    #: (:class:`sqlalchemy.types.String`)
+    filename = Column(Unicode(100))
+    #: MIME type of the blob
+    #: (:class:`sqlalchemy.types.String`)
+    content_type = Column(String(30))
+    #: Size of the blob in bytes
+    #: (:class:`sqlalchemy.types.Integer`)
+    content_length = Column(Integer())
+    #: Date / time the blob was created
+    #: (:class:`sqlalchemy.types.DateTime`)
+    last_modified = Column(DateTime())
+    #: The binary data itself
+    #: (:class:`sqlalchemy.types.LargeBinary`)
+    data = deferred(Column('data', LargeBinary()))
+
+    def read(self, n=-1):  # pragma: no cover
+        """Reads ``n`` bytes from the file.
+
+        If ``n`` is not specified or is ``-1`` the whole
+        file content is read in memory and returned
+        """
+        return
+
+    def close(self, *args, **kwargs):  # pragma: no cover
+        """Closes the file.
+
+        After closing the file it won't be possible to read
+        from it anymore. Some implementation might not do anything
+        when closing the file, but they still are required to prevent
+        further reads from a closed file.
+        """
+        return
+
+    def closed(self):  # pragma: no cover
+        """Returns if the file has been closed.
+
+        When ``closed`` return ``True`` it won't be possible
+        to read anoymore from this file.
+        """
+        return
+
+
+class DBFileStorage(FileStorage):
+    """ depotfile FileStorage implementation, uses DBStoredFile to store data
+    """
+
+    def get(self, file_id):
+        """Returns the file given by the file_id
+        """
+
+        f = DBSession.query(DBStoredFile).filter_by(file_id=file_id).first()
+        if f is None:
+            raise IOError
+        return f
+
+    def create(self, content, filename=None, content_type=None):
+        """Saves a new file and returns the file id
+
+        ``content`` parameter can either be ``bytes``, another ``file object``
+        or a :class:`cgi.FieldStorage`. When ``filename`` and ``content_type``
+        parameters are not provided they are deducted from the content itself.
+        """
+        new_file_id = str(uuid.uuid1())
+        content, filename, content_type = self.fileinfo(
+            content, filename, content_type)
+        if hasattr(content, 'read'):
+            content = content.read()
+
+        fstore = DBStoredFile(data=content,
+                              file_id=new_file_id,
+                              filename=filename,
+                              content_type=content_type,
+                              content_length=len(content),
+                              last_modified=datetime.now())
+        DBSession.add(fstore)
+        return new_file_id
+
+    def replace(self, file_or_id, content, filename=None, content_type=None):  # pragma: no cover
+        """Replaces an existing file, an ``IOError`` is raised if the file didn't already exist.
+
+        Given a :class:`StoredFile` or its ID it will replace the current content
+        with the provided ``content`` value. If ``filename`` and ``content_type`` are
+        provided or can be deducted by the ``content`` itself they will also replace
+        the previous values, otherwise the current values are kept.
+        """
+
+        if isinstance(file_or_id, StoredFile):
+            file_id = file_or_id.file_id
+        else:
+            file_id = file_or_id
+
+        content, filename, content_type = self.fileinfo(
+            content, filename, content_type)
+
+        fstore = self.get(file_id)
+
+        if filename is not None:
+            fstore.filename = filename
+        if content_type is not None:
+            fstore.content_type = content_type
+
+        if hasattr(content, 'read'):
+            content = content.read()
+
+        fstore.data = content
+
+    def delete(self, file_or_id):  # pragma: no cover
+        """Deletes a file. If the file didn't exist it will just do nothing."""
+
+        if isinstance(file_or_id, StoredFile):
+            file_id = file_or_id.file_id
+        else:
+            file_id = file_or_id
+        fstore = self.get(file_id)
+        DBSession.delete(fstore)
+
+    def exists(self, file_or_id):  # pragma: no cover
+        """Returns if a file or its ID still exist."""
+        if isinstance(file_or_id, StoredFile):
+            file_id = file_or_id.file_id
+        else:
+            file_id = file_or_id
+        return bool(
+            DBSession.query(StoredFile).filter_by(file_id=file_id).count())

--- a/kotti/filedepot.py
+++ b/kotti/filedepot.py
@@ -257,7 +257,7 @@ def includeme(config):
     from kotti.events import objectevent_listeners
     from kotti.events import ObjectInsert
     from kotti.events import ObjectUpdate
-    #from sqlalchemy import event
+    from depot.fields.sqlalchemy import _SQLAMutationTracker
 
     configure_filedepot(config.get_settings())
 
@@ -267,4 +267,9 @@ def includeme(config):
     objectevent_listeners[
         (ObjectUpdate, DBStoredFile)].append(set_metadata)
 
-    #event.listen(DBStoredFile, 'load', DBStoredFile.set_cursor)
+    # depot's _SQLAMutationTracker._session_committed is executed on
+    # after_commit, that's too late for DBFileStorage to interact with the
+    # session
+    event.listen(DBSession,
+                 'before_commit',
+                 _SQLAMutationTracker._session_committed)

--- a/kotti/filedepot.py
+++ b/kotti/filedepot.py
@@ -35,7 +35,7 @@ class DBStoredFile(Base):   #, StoredFile):
     filename = Column(Unicode(100))
     #: MIME type of the blob
     #: (:class:`sqlalchemy.types.String`)
-    content_type = Column(String(30))
+    content_type = Column(String(100))
     #: Size of the blob in bytes
     #: (:class:`sqlalchemy.types.Integer`)
     content_length = Column(Integer())

--- a/kotti/filedepot.py
+++ b/kotti/filedepot.py
@@ -46,8 +46,8 @@ class DBStoredFile(Base):
     #: (:class:`sqlalchemy.types.LargeBinary`)
     data = deferred(Column('data', LargeBinary()))
 
-    def __init__(self, file_id, filename=None, content_type=None, last_modified=None,
-                 content_length=None, **kwds):
+    def __init__(self, file_id, filename=None, content_type=None,
+                 last_modified=None, content_length=None, **kwds):
         self.file_id = file_id
         self.filename = filename
         self.content_type = content_type

--- a/kotti/filedepot.py
+++ b/kotti/filedepot.py
@@ -193,8 +193,9 @@ class DBFileStorage(FileStorage):
         """Saves a new file and returns the file id
 
         :param content: can either be ``bytes``, another ``file object``
-        or a :class:`cgi.FieldStorage`. When ``filename`` and ``content_type``
-        parameters are not provided they are deducted from the content itself.
+                        or a :class:`cgi.FieldStorage`. When ``filename`` and
+                        ``content_type``  parameters are not provided they are
+                        deducted from the content itself.
 
         :param filename: filename for this file
         :type filename: string
@@ -232,8 +233,9 @@ class DBFileStorage(FileStorage):
         :param file_or_id: can be either ``DBStoredFile`` or a ``file_id``
 
         :param content: can either be ``bytes``, another ``file object``
-        or a :class:`cgi.FieldStorage`. When ``filename`` and ``content_type``
-        parameters are not provided they are deducted from the content itself.
+                        or a :class:`cgi.FieldStorage`. When ``filename`` and
+                        ``content_type`` parameters are not provided they are
+                        deducted from the content itself.
 
         :param filename: filename for this file
         :type filename: string

--- a/kotti/filedepot.py
+++ b/kotti/filedepot.py
@@ -322,3 +322,9 @@ def includeme(config):
     event.listen(DBSession,
                  'before_commit',
                  _SQLAMutationTracker._session_committed)
+
+    # adjust for engine type
+    engine = DBSession.connection().engine
+    if engine.dialect.name == 'mysql':  # pragma: no cover
+        from sqlalchemy.dialects.mysql.base import LONGBLOB
+        DBStoredFile.__table__.c.data.type = LONGBLOB()

--- a/kotti/filedepot.py
+++ b/kotti/filedepot.py
@@ -15,7 +15,7 @@ from kotti import Base
 from kotti import DBSession
 
 
-class DBStoredFile(Base):   #, StoredFile):
+class DBStoredFile(Base):
     """depotfile StoredFile implementation that stores data in the db.
 
     Can be used together with DBFileStorage to implement blobs (large files)

--- a/kotti/filedepot.py
+++ b/kotti/filedepot.py
@@ -14,6 +14,7 @@ from kotti import DBSession
 
 import uuid
 
+
 class CooperativeMeta(type):
     def __new__(cls, name, bases, members):
         # collect up the metaclasses
@@ -176,3 +177,17 @@ class DBFileStorage(FileStorage):
             file_id = file_or_id
         return bool(
             DBSession.query(StoredFile).filter_by(file_id=file_id).count())
+
+
+def configure_filedepot(settings):
+    from kotti.util import flatdotted_to_dict
+    from depot.manager import DepotManager
+
+    config = flatdotted_to_dict('kotti.depot.', settings)
+    for name, conf in config.items():
+        if DepotManager.get(name) is None:
+            DepotManager.configure(name, conf, prefix='')
+
+
+def includeme(config):
+    configure_filedepot(config.get_settings())

--- a/kotti/filedepot.py
+++ b/kotti/filedepot.py
@@ -17,6 +17,7 @@ from kotti import DBSession
 
 _marker = object()
 
+
 class DBStoredFile(Base):
     """depotfile StoredFile implementation that stores data in the db.
 

--- a/kotti/filedepot.py
+++ b/kotti/filedepot.py
@@ -344,8 +344,8 @@ def migrate_storages_command():  # pragma: no cover
 
     Options:
       -h --help                 Show this screen.
-      --from-storage <number>   The storage name that has blob data to migrate
-      --to-storage <number>     The storage name where we want to put the blobs
+      --from-storage <name>   The storage name that has blob data to migrate
+      --to-storage <name>     The storage name where we want to put the blobs
     """
     return command(
         lambda args: migrate_storage(

--- a/kotti/filedepot.py
+++ b/kotti/filedepot.py
@@ -286,12 +286,13 @@ class DBFileStorage(FileStorage):
 
 
 def configure_filedepot(settings):
-    from kotti.util import flatdotted_to_dict
+    from kotti.util import extract_depot_settings
     from depot.manager import DepotManager
 
-    config = flatdotted_to_dict('kotti.depot.', settings)
-    for name, conf in config.items():
-        if DepotManager.get(name) is None:
+    config = extract_depot_settings('kotti.depot.', settings)
+    for conf in config:
+        name = conf.pop('name')
+        if name not in DepotManager._depots:
             DepotManager.configure(name, conf, prefix='')
 
 

--- a/kotti/filedepot.py
+++ b/kotti/filedepot.py
@@ -112,7 +112,7 @@ def set_metadata(event):
     """Set DBStoredFile metadata based on data
 
     :param event: event that trigerred this handler.
-    :type event: :class:`ObjectInsert` and :class:`ObjectUpdate`
+    :type event: :class:`ObjectInsert` or :class:`ObjectUpdate`
     """
     obj = event.object
     obj.content_length = obj.data and len(obj.data) or 0

--- a/kotti/resources.py
+++ b/kotti/resources.py
@@ -9,18 +9,14 @@ Inheritance Diagram
 """
 
 import os
-import uuid
 import warnings
 
-from datetime import datetime
 from fnmatch import fnmatch
 from UserDict import DictMixin
 
 from depot.fields.sqlalchemy import UploadedFileField
 from depot.fields.sqlalchemy import _SQLAMutationTracker
-from depot.io.interfaces import StoredFile, FileStorage
 
-from pyramid.threadlocal import get_current_registry
 from pyramid.traversal import resource_path
 from sqlalchemy import event
 from sqlalchemy import Boolean
@@ -28,7 +24,6 @@ from sqlalchemy import Column
 from sqlalchemy import DateTime
 from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
-from sqlalchemy import LargeBinary
 from sqlalchemy import String
 from sqlalchemy import Unicode
 from sqlalchemy import UnicodeText
@@ -37,7 +32,6 @@ from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.orderinglist import ordering_list
 from sqlalchemy.orm import backref
-from sqlalchemy.orm import deferred
 from sqlalchemy.orm import object_mapper
 from sqlalchemy.orm import relation
 from sqlalchemy.orm.exc import NoResultFound
@@ -733,174 +727,6 @@ class Image(File):
         selectable_default_views=[],
         uploadable_mimetypes=['image/*', ],
         )
-
-
-class CooperativeMeta(type):
-    def __new__(cls, name, bases, members):
-        #collect up the metaclasses
-        metas = [type(base) for base in bases]
-
-        # prune repeated or conflicting entries
-        metas = [meta for index, meta in enumerate(metas)
-            if not [later for later in metas[index+1:]
-                if issubclass(later, meta)]]
-
-        # whip up the actual combined meta class derive off all of these
-        meta = type(name, tuple(metas), dict(combined_metas = metas))
-
-        # make the actual object
-        return meta(name, bases, members)
-
-    def __init__(self, name, bases, members):
-        for meta in self.combined_metas:
-            meta.__init__(self, name, bases, members)
-
-
-class DBStoredFile(Base, StoredFile):
-    """depotfile StoredFile implementation that stores data in the db.
-
-    Can be used together with DBFileStorage to implement blobs (large files)
-    storage in the database.
-    """
-
-    __tablename__ = "blobs"
-    __metaclass__ = CooperativeMeta
-
-    #: Primary key column in the DB
-    #: (:class:`sqlalchemy.types.Integer`)
-    id = Column(Integer(), primary_key=True)
-    #: Unique id given to this blob
-    #: (:class:`sqlalchemy.types.String`)
-    file_id = Column(String(36), index=True)
-    #: The original filename it had when it was uploaded.
-    #: (:class:`sqlalchemy.types.String`)
-    filename = Column(Unicode(100))
-    #: MIME type of the blob
-    #: (:class:`sqlalchemy.types.String`)
-    content_type = Column(String(30))
-    #: Size of the blob in bytes
-    #: (:class:`sqlalchemy.types.Integer`)
-    content_length = Column(Integer())
-    #: Date / time the blob was created
-    #: (:class:`sqlalchemy.types.DateTime`)
-    last_modified = Column(DateTime())
-    #: The binary data itself
-    #: (:class:`sqlalchemy.types.LargeBinary`)
-    data = deferred(Column('data', LargeBinary()))
-
-    # def __init__(self, **kw):
-    #     for k, v in kw.items():
-    #         setattr(self, k, v)
-
-    def read(self, n=-1):  # pragma: no cover
-        """Reads ``n`` bytes from the file.
-
-        If ``n`` is not specified or is ``-1`` the whole
-        file content is read in memory and returned
-        """
-        return
-
-    def close(self, *args, **kwargs):  # pragma: no cover
-        """Closes the file.
-
-        After closing the file it won't be possible to read
-        from it anymore. Some implementation might not do anything
-        when closing the file, but they still are required to prevent
-        further reads from a closed file.
-        """
-        return
-
-    def closed(self):  # pragma: no cover
-        """Returns if the file has been closed.
-
-        When ``closed`` return ``True`` it won't be possible
-        to read anoymore from this file.
-        """
-        return
-
-
-class DBFileStorage(FileStorage):
-    """ depotfile FileStorage implementation, uses DBStoredFile to store data
-    """
-
-    def get(self, file_id):
-        """Returns the file given by the file_id
-        """
-
-        f = DBSession.query(DBStoredFile).filter_by(file_id=file_id).first()
-        if f is None:
-            raise IOError
-        return f
-
-    def create(self, content, filename=None, content_type=None):
-        """Saves a new file and returns the file id
-
-        ``content`` parameter can either be ``bytes``, another ``file object``
-        or a :class:`cgi.FieldStorage`. When ``filename`` and ``content_type``
-        parameters are not provided they are deducted from the content itself.
-        """
-        new_file_id = str(uuid.uuid1())
-        content, filename, content_type = self.fileinfo(
-            content, filename, content_type)
-        if hasattr(content, 'read'):
-            content = content.read()
-
-        fstore = DBStoredFile(data=content,
-                              file_id=new_file_id,
-                              filename=filename,
-                              content_type=content_type,
-                              content_length=len(content),
-                              last_modified=datetime.now())
-        DBSession.add(fstore)
-        return new_file_id
-
-    def replace(self, file_or_id, content, filename=None, content_type=None):  # pragma: no cover
-        """Replaces an existing file, an ``IOError`` is raised if the file didn't already exist.
-
-        Given a :class:`StoredFile` or its ID it will replace the current content
-        with the provided ``content`` value. If ``filename`` and ``content_type`` are
-        provided or can be deducted by the ``content`` itself they will also replace
-        the previous values, otherwise the current values are kept.
-        """
-
-        if isinstance(file_or_id, StoredFile):
-            file_id = file_or_id.file_id
-        else:
-            file_id = file_or_id
-
-        content, filename, content_type = self.fileinfo(
-            content, filename, content_type)
-
-        fstore = self.get(file_id)
-
-        if filename is not None:
-            fstore.filename = filename
-        if content_type is not None:
-            fstore.content_type = content_type
-
-        if hasattr(content, 'read'):
-            content = content.read()
-
-        fstore.data = content
-
-    def delete(self, file_or_id):  # pragma: no cover
-        """Deletes a file. If the file didn't exist it will just do nothing."""
-
-        if isinstance(file_or_id, StoredFile):
-            file_id = file_or_id.file_id
-        else:
-            file_id = file_or_id
-        fstore = self.get(file_id)
-        DBSession.delete(fstore)
-
-    def exists(self, file_or_id):  # pragma: no cover
-        """Returns if a file or its ID still exist."""
-        if isinstance(file_or_id, StoredFile):
-            file_id = file_or_id.file_id
-        else:
-            file_id = file_or_id
-        return bool(
-            DBSession.query(StoredFile).filter_by(file_id=file_id).count())
 
 
 def get_root(request=None):

--- a/kotti/resources.py
+++ b/kotti/resources.py
@@ -35,7 +35,6 @@ from sqlalchemy.orm import backref
 from sqlalchemy.orm import object_mapper
 from sqlalchemy.orm import relation
 from sqlalchemy.orm.exc import NoResultFound
-from sqlalchemy.orm import ColumnProperty
 from sqlalchemy.sql import and_
 from sqlalchemy.sql import select
 from sqlalchemy.util import classproperty

--- a/kotti/resources.py
+++ b/kotti/resources.py
@@ -712,17 +712,6 @@ class File(Content):
         # filedepot already registers this event listener, but it does so in a
         # way that won't work properly for subclasses of File
 
-        # mapper = cls._sa_class_manager.mapper
-        # for mapper_property in mapper.iterate_properties:
-        #     if isinstance(mapper_property, ColumnProperty):
-        #         for idx, col in enumerate(mapper_property.columns):
-        #             if isinstance(col.type, UploadedFileField):
-        #                 event.listen(
-        #                     getattr(cls, col.name),
-        #                     'set',
-        #                     _SQLAMutationTracker._field_set,
-        #                     retval=True
-        #                 )
         event.listen(cls.data, 'set', cls.set_metadata, retval=True)
 
     @classmethod

--- a/kotti/resources.py
+++ b/kotti/resources.py
@@ -9,12 +9,16 @@ Inheritance Diagram
 """
 
 import os
+import uuid
 import warnings
+
+from datetime import datetime
 from fnmatch import fnmatch
 from UserDict import DictMixin
 
 from depot.fields.sqlalchemy import UploadedFileField
 from depot.fields.sqlalchemy import _SQLAMutationTracker
+from depot.io.interfaces import StoredFile, FileStorage
 
 from pyramid.threadlocal import get_current_registry
 from pyramid.traversal import resource_path
@@ -647,8 +651,8 @@ class File(Content):
     #: Primary key column in the DB
     #: (:class:`sqlalchemy.types.Integer`)
     id = Column(Integer(), ForeignKey('contents.id'), primary_key=True)
-    #: The binary data itself
-    #: (:class:`sqlalchemy.types.LargeBinary`)
+    #: Filedepot mapped blob
+    #: (:class:`depot.fileds.sqlalchemy.UploadedFileField`)
     data = Column(UploadedFileField)
     #: The filename is used in the attachment view to give downloads
     #: the original filename it had when it was uploaded.
@@ -729,6 +733,174 @@ class Image(File):
         selectable_default_views=[],
         uploadable_mimetypes=['image/*', ],
         )
+
+
+class CooperativeMeta(type):
+    def __new__(cls, name, bases, members):
+        #collect up the metaclasses
+        metas = [type(base) for base in bases]
+
+        # prune repeated or conflicting entries
+        metas = [meta for index, meta in enumerate(metas)
+            if not [later for later in metas[index+1:]
+                if issubclass(later, meta)]]
+
+        # whip up the actual combined meta class derive off all of these
+        meta = type(name, tuple(metas), dict(combined_metas = metas))
+
+        # make the actual object
+        return meta(name, bases, members)
+
+    def __init__(self, name, bases, members):
+        for meta in self.combined_metas:
+            meta.__init__(self, name, bases, members)
+
+
+class DBStoredFile(Base, StoredFile):
+    """depotfile StoredFile implementation that stores data in the db.
+
+    Can be used together with DBFileStorage to implement blobs (large files)
+    storage in the database.
+    """
+
+    __tablename__ = "blobs"
+    __metaclass__ = CooperativeMeta
+
+    #: Primary key column in the DB
+    #: (:class:`sqlalchemy.types.Integer`)
+    id = Column(Integer(), primary_key=True)
+    #: Unique id given to this blob
+    #: (:class:`sqlalchemy.types.String`)
+    file_id = Column(String(36), index=True)
+    #: The original filename it had when it was uploaded.
+    #: (:class:`sqlalchemy.types.String`)
+    filename = Column(Unicode(100))
+    #: MIME type of the blob
+    #: (:class:`sqlalchemy.types.String`)
+    content_type = Column(String(30))
+    #: Size of the blob in bytes
+    #: (:class:`sqlalchemy.types.Integer`)
+    content_length = Column(Integer())
+    #: Date / time the blob was created
+    #: (:class:`sqlalchemy.types.DateTime`)
+    last_modified = Column(DateTime())
+    #: The binary data itself
+    #: (:class:`sqlalchemy.types.LargeBinary`)
+    data = deferred(Column('data', LargeBinary()))
+
+    # def __init__(self, **kw):
+    #     for k, v in kw.items():
+    #         setattr(self, k, v)
+
+    def read(self, n=-1):  # pragma: no cover
+        """Reads ``n`` bytes from the file.
+
+        If ``n`` is not specified or is ``-1`` the whole
+        file content is read in memory and returned
+        """
+        return
+
+    def close(self, *args, **kwargs):  # pragma: no cover
+        """Closes the file.
+
+        After closing the file it won't be possible to read
+        from it anymore. Some implementation might not do anything
+        when closing the file, but they still are required to prevent
+        further reads from a closed file.
+        """
+        return
+
+    def closed(self):  # pragma: no cover
+        """Returns if the file has been closed.
+
+        When ``closed`` return ``True`` it won't be possible
+        to read anoymore from this file.
+        """
+        return
+
+
+class DBFileStorage(FileStorage):
+    """ depotfile FileStorage implementation, uses DBStoredFile to store data
+    """
+
+    def get(self, file_id):
+        """Returns the file given by the file_id
+        """
+
+        f = DBSession.query(DBStoredFile).filter_by(file_id=file_id).first()
+        if f is None:
+            raise IOError
+        return f
+
+    def create(self, content, filename=None, content_type=None):
+        """Saves a new file and returns the file id
+
+        ``content`` parameter can either be ``bytes``, another ``file object``
+        or a :class:`cgi.FieldStorage`. When ``filename`` and ``content_type``
+        parameters are not provided they are deducted from the content itself.
+        """
+        new_file_id = str(uuid.uuid1())
+        content, filename, content_type = self.fileinfo(
+            content, filename, content_type)
+        if hasattr(content, 'read'):
+            content = content.read()
+
+        fstore = DBStoredFile(data=content,
+                              file_id=new_file_id,
+                              filename=filename,
+                              content_type=content_type,
+                              content_length=len(content),
+                              last_modified=datetime.now())
+        DBSession.add(fstore)
+        return new_file_id
+
+    def replace(self, file_or_id, content, filename=None, content_type=None):  # pragma: no cover
+        """Replaces an existing file, an ``IOError`` is raised if the file didn't already exist.
+
+        Given a :class:`StoredFile` or its ID it will replace the current content
+        with the provided ``content`` value. If ``filename`` and ``content_type`` are
+        provided or can be deducted by the ``content`` itself they will also replace
+        the previous values, otherwise the current values are kept.
+        """
+
+        if isinstance(file_or_id, StoredFile):
+            file_id = file_or_id.file_id
+        else:
+            file_id = file_or_id
+
+        content, filename, content_type = self.fileinfo(
+            content, filename, content_type)
+
+        fstore = self.get(file_id)
+
+        if filename is not None:
+            fstore.filename = filename
+        if content_type is not None:
+            fstore.content_type = content_type
+
+        if hasattr(content, 'read'):
+            content = content.read()
+
+        fstore.data = content
+
+    def delete(self, file_or_id):  # pragma: no cover
+        """Deletes a file. If the file didn't exist it will just do nothing."""
+
+        if isinstance(file_or_id, StoredFile):
+            file_id = file_or_id.file_id
+        else:
+            file_id = file_or_id
+        fstore = self.get(file_id)
+        DBSession.delete(fstore)
+
+    def exists(self, file_or_id):  # pragma: no cover
+        """Returns if a file or its ID still exist."""
+        if isinstance(file_or_id, StoredFile):
+            file_id = file_or_id.file_id
+        else:
+            file_id = file_or_id
+        return bool(
+            DBSession.query(StoredFile).filter_by(file_id=file_id).count())
 
 
 def get_root(request=None):

--- a/kotti/resources.py
+++ b/kotti/resources.py
@@ -12,6 +12,7 @@ import os
 import warnings
 
 from fnmatch import fnmatch
+from cStringIO import StringIO
 from UserDict import DictMixin
 
 from depot.fields.sqlalchemy import UploadedFileField
@@ -62,6 +63,7 @@ from kotti.sqla import JsonType
 from kotti.sqla import MutationList
 from kotti.sqla import NestedMutationDict
 from kotti.util import _
+from kotti.util import _to_fieldstorage
 from kotti.util import camel_case_to_name
 from kotti.util import get_paste_items
 from kotti.util import Link
@@ -673,10 +675,13 @@ class File(Content):
 
         super(File, self).__init__(**kwargs)
 
-        self.data = data
         self.filename = filename
         self.mimetype = mimetype
         self.size = size
+        if isinstance(data, basestring):
+            data = _to_fieldstorage(fp=StringIO(data), filename=filename,
+                                    mimetype=mimetype, size=size)
+        self.data = data
 
     @classmethod
     def from_field_storage(cls, fs):
@@ -728,8 +733,9 @@ class File(Content):
         if newvalue is None:
             return
 
-        target.mimetype = newvalue.file.content_type
+        target.filename = newvalue.filename
         target.size = newvalue.file.content_length
+        target.mimetype = newvalue.content_type
         return newvalue
 
 

--- a/kotti/resources.py
+++ b/kotti/resources.py
@@ -649,7 +649,6 @@ class File(Content):
     id = Column(Integer(), ForeignKey('contents.id'), primary_key=True)
     #: The binary data itself
     #: (:class:`sqlalchemy.types.LargeBinary`)
-    #data = deferred(Column("data", LargeBinary()))
     data = Column(UploadedFileField)
     #: The filename is used in the attachment view to give downloads
     #: the original filename it had when it was uploaded.

--- a/kotti/resources.py
+++ b/kotti/resources.py
@@ -702,13 +702,12 @@ class File(Content):
     def __declare_last__(cls):
         # Unconfigure the event set in _SQLAMutationTracker, we have _save_data
         mapper = cls._sa_class_manager.mapper
-        prop = mapper.attrs['data']
-        args = (prop, 'set', _SQLAMutationTracker._field_set)
+        args = (mapper.attrs['data'], 'set', _SQLAMutationTracker._field_set)
         if event.contains(*args):
             event.remove(*args)
 
         # Declaring the event on the class attribute instead of mapper property
-        # enables its registration on subclasses
+        # enables proper registration on its subclasses
         event.listen(cls.data, 'set', cls._save_data, retval=True)
 
     @classmethod
@@ -788,8 +787,6 @@ def default_get_root(request=None):
 
 def _adjust_for_engine(engine):
     if engine.dialect.name == 'mysql':  # pragma: no cover
-        from sqlalchemy.dialects.mysql.base import LONGBLOB
-        File.__table__.c.data.type = LONGBLOB()
         # We disable the Node.path index for Mysql; in some conditions
         # the index can't be created for columns even with 767 bytes,
         # the maximum default size for column indexes

--- a/kotti/resources.py
+++ b/kotti/resources.py
@@ -35,6 +35,7 @@ from sqlalchemy.orm import backref
 from sqlalchemy.orm import object_mapper
 from sqlalchemy.orm import relation
 from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.orm import ColumnProperty
 from sqlalchemy.sql import and_
 from sqlalchemy.sql import select
 from sqlalchemy.util import classproperty
@@ -706,8 +707,31 @@ class File(Content):
         # For the ``data`` column, use the field value setter from filedepot.
         # filedepot already registers this event listener, but it does so in a
         # way that won't work properly for subclasses of File
-        event.listen(cls.data, 'set',
-                     _SQLAMutationTracker._field_set, retval=True)
+
+        # mapper = cls._sa_class_manager.mapper
+        # for mapper_property in mapper.iterate_properties:
+        #     if isinstance(mapper_property, ColumnProperty):
+        #         for idx, col in enumerate(mapper_property.columns):
+        #             if isinstance(col.type, UploadedFileField):
+        #                 event.listen(
+        #                     getattr(cls, col.name),
+        #                     'set',
+        #                     _SQLAMutationTracker._field_set,
+        #                     retval=True
+        #                 )
+        event.listen(cls.data, 'set', cls.set_metadata, retval=True)
+
+    @classmethod
+    def set_metadata(cls, target, value, oldvalue, initiator):
+        newvalue = _SQLAMutationTracker._field_set(
+            target, value, oldvalue, initiator)
+
+        if newvalue is None:
+            return
+
+        target.mimetype = newvalue.file.content_type
+        target.size = newvalue.file.content_length
+        return newvalue
 
 
 class Image(File):

--- a/kotti/resources.py
+++ b/kotti/resources.py
@@ -694,15 +694,10 @@ class File(Content):
         :rtype: :class:`kotti.resources.File`
         """
 
-        data = fs.file.read()
-        filename = fs.filename
-        mimetype = fs.type
-        size = len(data)
+        if not cls.type_info.is_uploadable_mimetype(fs.type):
+            raise ValueError("Unsupported MIME type: %s" % fs.type)
 
-        if not cls.type_info.is_uploadable_mimetype(mimetype):
-            raise ValueError("Unsupported MIME type: %s" % mimetype)
-
-        return cls(data=data, filename=filename, mimetype=mimetype, size=size)
+        return cls(data=fs)
 
     @classmethod
     def __declare_last__(cls):
@@ -750,8 +745,8 @@ class File(Content):
             target.filename = newvalue.filename
         if newvalue.content_type:
             target.mimetype = newvalue.content_type
-
         target.size = newvalue.file.content_length
+
         return newvalue
 
 

--- a/kotti/resources.py
+++ b/kotti/resources.py
@@ -716,6 +716,13 @@ class File(Content):
 
     @classmethod
     def set_metadata(cls, target, value, oldvalue, initiator):
+        """ Refresh metadata and save the binary data to the data field.
+
+        :param target: The File instance
+        :type target: :class:`kotti.resources.File` or subclass
+        :param value: The container for binary data
+        :type value: A :class:`cgi.FieldStorage` instance
+        """
         newvalue = _SQLAMutationTracker._field_set(
             target, value, oldvalue, initiator)
 

--- a/kotti/tests/__init__.py
+++ b/kotti/tests/__init__.py
@@ -301,9 +301,14 @@ def filedepot(db_session, request):
                     return info['content']
                 return None
 
-            f = MagicMock()
+            def seek(n=0):
+                finished[:]
+
+            from StringIO import StringIO
+
+            f = MagicMock(wraps=StringIO(info['content']))
+            f.seek(0)
             f.public_url = ''
-            f.read = read
             f.filename = info['filename']
             f.content_type = info['content_type']
             f.content_length = len(info['content'])

--- a/kotti/tests/__init__.py
+++ b/kotti/tests/__init__.py
@@ -291,22 +291,31 @@ def filedepot(db_session, request):
             self._storage.setdefault(0)
 
         def get(self, id):
+            content = self._storage[id]['content']
             f = MagicMock()
-            f.read.return_value = self._storage[id]
+            f.read.return_value = content
+
+            f.filename = self._storage[id]['filename']
+            f.public_url = ''
+            f.content_type = 'image/png'
+            f.content_length = len(content)
 
             # needed to make JSON serializable, Mock objects are not
             f.last_modified = datetime.now()
-            f.filename = str(id)
-            f.public_url = ''
-            f.content_type = 'image/png'
 
             return f
 
         def create(self, content, filename=None, content_type=None):
             id = max(self._storage) + 1
+            if hasattr(content, 'filename'):
+                filename = filename or content.filename
+            if hasattr(content, 'type'):
+                content_type = content_type or content.type
             if hasattr(content, 'read'):
                 content = content.read()
-            self._storage[id] = content
+            elif hasattr(content, 'file'):
+                content = content.file.read()
+            self._storage[id] = {'content': content, 'filename': filename}
             return id
 
         def delete(self, id):

--- a/kotti/tests/__init__.py
+++ b/kotti/tests/__init__.py
@@ -282,6 +282,8 @@ def workflow(config):
 
 @fixture
 def filedepot(db_session, request):
+    """ Configures a mock depot store for :class:`depot.manager.DepotManager`
+    """
     from depot.manager import DepotManager
     from datetime import datetime
 

--- a/kotti/tests/__init__.py
+++ b/kotti/tests/__init__.py
@@ -313,9 +313,11 @@ def filedepot(request):
             del self._storage[int(id)]
 
     DepotManager._depots = {
-        'default': MagicMock(wraps=TestStorage())
+        'mockdepot': MagicMock(wraps=TestStorage())
     }
+    DepotManager._default_depot = 'mockdepot'
 
     def restore():
         DepotManager._depots = {}
+        DepotManager._default_depot = None
     request.addfinalizer(restore)

--- a/kotti/tests/__init__.py
+++ b/kotti/tests/__init__.py
@@ -349,7 +349,6 @@ def no_filedepots(db_session, request):
     DepotManager._depots = {}
     DepotManager._default_depot = None
 
-
     def restore():
         db_session.rollback()
         DepotManager._depots = _old_depots

--- a/kotti/tests/__init__.py
+++ b/kotti/tests/__init__.py
@@ -293,17 +293,6 @@ def filedepot(db_session, request):
         def get(self, id):
             info = self._storage[id]
 
-            finished = []
-
-            def read(block_size=-1):
-                if not finished:
-                    finished.append(True)
-                    return info['content']
-                return None
-
-            def seek(n=0):
-                finished[:]
-
             from StringIO import StringIO
 
             f = MagicMock(wraps=StringIO(info['content']))

--- a/kotti/tests/__init__.py
+++ b/kotti/tests/__init__.py
@@ -294,6 +294,7 @@ def filedepot(db_session, request):
             info = self._storage[id]
 
             finished = []
+
             def read(block_size=-1):
                 if not finished:
                     finished.append(True)

--- a/kotti/tests/__init__.py
+++ b/kotti/tests/__init__.py
@@ -335,3 +335,24 @@ def filedepot(db_session, request):
         DepotManager._default_depot = _old_default_depot
 
     request.addfinalizer(restore)
+
+
+@fixture
+def no_filedepots(db_session, request):
+    """ A filedepot fixture to empty and then restore DepotManager configuration
+    """
+    from depot.manager import DepotManager
+
+    _old_depots = DepotManager._depots
+    _old_default_depot = DepotManager._default_depot
+
+    DepotManager._depots = {}
+    DepotManager._default_depot = None
+
+
+    def restore():
+        db_session.rollback()
+        DepotManager._depots = _old_depots
+        DepotManager._default_depot = _old_default_depot
+
+    request.addfinalizer(restore)

--- a/kotti/tests/__init__.py
+++ b/kotti/tests/__init__.py
@@ -312,12 +312,15 @@ def filedepot(request):
         def delete(self, id):
             del self._storage[int(id)]
 
+    _old_depots = DepotManager._depots
+    _old_default_depot = DepotManager._default_depot
     DepotManager._depots = {
         'mockdepot': MagicMock(wraps=TestStorage())
     }
     DepotManager._default_depot = 'mockdepot'
 
     def restore():
-        DepotManager._depots = {}
-        DepotManager._default_depot = None
+        DepotManager._depots = _old_depots
+        DepotManager._default_depot = _old_default_depot
+
     request.addfinalizer(restore)

--- a/kotti/tests/__init__.py
+++ b/kotti/tests/__init__.py
@@ -300,7 +300,7 @@ def filedepot(db_session, request):
             f.content_type = info['content_type']
             f.content_length = len(info['content'])
             # needed to make JSON serializable, Mock objects are not
-            f.last_modified = datetime.now()
+            f.last_modified = datetime(2012, 12, 30)
 
             return f
 

--- a/kotti/tests/__init__.py
+++ b/kotti/tests/__init__.py
@@ -9,7 +9,6 @@ Fixture dependencies
 
    digraph kotti_fixtures {
       "allwarnings";
-      "filedepot";
       "app" -> "webtest";
       "config" -> "db_session";
       "config" -> "dummy_request";
@@ -23,6 +22,7 @@ Fixture dependencies
       "db_session" -> "app";
       "db_session" -> "browser";
       "db_session" -> "root";
+      "db_session" -> "filedepot";
       "dummy_mailer" -> "app";
       "dummy_mailer";
       "events" -> "app";
@@ -281,7 +281,7 @@ def workflow(config):
 
 
 @fixture
-def filedepot(request, db_session):
+def filedepot(db_session, request):
     from depot.manager import DepotManager
     from datetime import datetime
 

--- a/kotti/tests/__init__.py
+++ b/kotti/tests/__init__.py
@@ -281,7 +281,7 @@ def workflow(config):
 
 
 @fixture
-def filedepot(request):
+def filedepot(request, db_session):
     from depot.manager import DepotManager
     from datetime import datetime
 
@@ -320,6 +320,7 @@ def filedepot(request):
     DepotManager._default_depot = 'mockdepot'
 
     def restore():
+        db_session.rollback()
         DepotManager._depots = _old_depots
         DepotManager._default_depot = _old_default_depot
 

--- a/kotti/tests/__init__.py
+++ b/kotti/tests/__init__.py
@@ -293,9 +293,16 @@ def filedepot(db_session, request):
         def get(self, id):
             info = self._storage[id]
 
+            finished = []
+            def read(block_size=-1):
+                if not finished:
+                    finished.append(True)
+                    return info['content']
+                return None
+
             f = MagicMock()
             f.public_url = ''
-            f.read.return_value = info['content']
+            f.read = read
             f.filename = info['filename']
             f.content_type = info['content_type']
             f.content_length = len(info['content'])

--- a/kotti/tests/test_app.py
+++ b/kotti/tests/test_app.py
@@ -158,7 +158,7 @@ class TestApp:
             main({}, **settings)
         assert DepotManager.get().__class__.__name__ == 'DBFileStorage'
 
-    def test_configure_filedepot(self):
+    def test_configure_filedepot(self, no_filedepots):
         from depot.manager import DepotManager
         from kotti.filedepot import configure_filedepot
         from kotti import tests
@@ -175,12 +175,6 @@ class TestApp:
             'kotti.depot.1.name': 'mongo',
         }
 
-        # depot.manager.DepotManager acts as singleton, save its settings
-        _depots = DepotManager._depots
-        _default_depot = DepotManager._default_depot
-        DepotManager._depots = {}
-        DepotManager._default_depot = None
-
         configure_filedepot(settings)
 
         assert DepotManager.get().marker == 'TFS1'
@@ -189,9 +183,6 @@ class TestApp:
 
         tests.TFS1.assert_called_with(location='/tmp')
         tests.TFS2.assert_called_with(uri='mongo://')
-
-        DepotManager._depots = _depots
-        DepotManager._default_depot = _default_depot
 
         del tests.TFS1
         del tests.TFS2

--- a/kotti/tests/test_app.py
+++ b/kotti/tests/test_app.py
@@ -156,7 +156,7 @@ class TestApp:
 
         with patch('kotti.resources.initialize_sql'):
             main({}, **settings)
-        assert DepotManager.get().__class__.__name__ == 'LocalFileStorage'
+        assert DepotManager.get().__class__.__name__ == 'DBFileStorage'
 
     def test_configure_filedepot(self):
         from depot.manager import DepotManager

--- a/kotti/tests/test_app.py
+++ b/kotti/tests/test_app.py
@@ -148,6 +148,45 @@ class TestApp:
         assert get_settings()['kotti_foo.site_title'] == u'K\xf6tti'
         assert get_settings()['foo.site_title'] == 'K\xc3\xb6tti'
 
+    def test_default_filedepot(self, db_session):
+        from kotti import main
+        from depot.manager import DepotManager
+
+        settings = self.required_settings()
+
+        with patch('kotti.resources.initialize_sql'):
+            main({}, **settings)
+        assert DepotManager.get().__class__.__name__ == 'LocalFileStorage'
+
+    def test_configure_filedepot(self):
+        from depot.manager import DepotManager
+        from kotti.filedepot import configure_filedepot
+        from kotti import tests
+
+        tests.TFS1 = Mock(return_value=Mock(marker="TFS1"))
+        tests.TFS2 = Mock(return_value=Mock(marker="TFS2"))
+
+        settings = {
+            'kotti.depot.default.backend': 'kotti.tests.TFS1',
+            'kotti.depot.default.location': '/tmp',
+            'kotti.depot.mongo.backend': 'kotti.tests.TFS2',
+            'kotti.depot.mongo.uri': 'mongo://',
+        }
+        depots = DepotManager._depots
+        DepotManager._depots = {}
+        configure_filedepot(settings)
+
+        assert DepotManager.get().marker == 'TFS1'
+        assert DepotManager.get('default').marker == 'TFS1'
+        assert DepotManager.get('mongo').marker == 'TFS2'
+
+        tests.TFS1.assert_called_with(location='/tmp')
+        tests.TFS2.assert_called_with(uri='mongo://')
+
+        DepotManager._depots = depots
+        del tests.TFS1
+        del tests.TFS2
+
     def test_search_content(self, db_session):
         from kotti import main
         from kotti.views.util import search_content

--- a/kotti/tests/test_app.py
+++ b/kotti/tests/test_app.py
@@ -172,9 +172,13 @@ class TestApp:
             'kotti.depot.mongo.backend': 'kotti.tests.TFS2',
             'kotti.depot.mongo.uri': 'mongo://',
         }
-        depots = DepotManager._depots
+
+        # depot.manager.DepotManager acts as singleton, save its settings
+        _depots = DepotManager._depots
+        _default_depot = DepotManager._default_depot
         DepotManager._depots = {}
         DepotManager._default_depot = None
+
         configure_filedepot(settings)
 
         assert DepotManager.get().marker == 'TFS1'
@@ -184,7 +188,9 @@ class TestApp:
         tests.TFS1.assert_called_with(location='/tmp')
         tests.TFS2.assert_called_with(uri='mongo://')
 
-        DepotManager._depots = depots
+        DepotManager._depots = _depots
+        DepotManager._default_depot = _default_depot
+
         del tests.TFS1
         del tests.TFS2
 

--- a/kotti/tests/test_app.py
+++ b/kotti/tests/test_app.py
@@ -174,6 +174,7 @@ class TestApp:
         }
         depots = DepotManager._depots
         DepotManager._depots = {}
+        DepotManager._default_depot = None
         configure_filedepot(settings)
 
         assert DepotManager.get().marker == 'TFS1'

--- a/kotti/tests/test_app.py
+++ b/kotti/tests/test_app.py
@@ -167,8 +167,8 @@ class TestApp:
         tests.TFS2 = Mock(return_value=Mock(marker="TFS2"))
 
         settings = {
-            'kotti.depot.default.backend': 'kotti.tests.TFS1',
-            'kotti.depot.default.location': '/tmp',
+            'kotti.depot.localfs.backend': 'kotti.tests.TFS1',
+            'kotti.depot.localfs.location': '/tmp',
             'kotti.depot.mongo.backend': 'kotti.tests.TFS2',
             'kotti.depot.mongo.uri': 'mongo://',
         }
@@ -178,7 +178,7 @@ class TestApp:
         configure_filedepot(settings)
 
         assert DepotManager.get().marker == 'TFS1'
-        assert DepotManager.get('default').marker == 'TFS1'
+        assert DepotManager.get('localfs').marker == 'TFS1'
         assert DepotManager.get('mongo').marker == 'TFS2'
 
         tests.TFS1.assert_called_with(location='/tmp')

--- a/kotti/tests/test_app.py
+++ b/kotti/tests/test_app.py
@@ -167,10 +167,12 @@ class TestApp:
         tests.TFS2 = Mock(return_value=Mock(marker="TFS2"))
 
         settings = {
-            'kotti.depot.localfs.backend': 'kotti.tests.TFS1',
-            'kotti.depot.localfs.location': '/tmp',
-            'kotti.depot.mongo.backend': 'kotti.tests.TFS2',
-            'kotti.depot.mongo.uri': 'mongo://',
+            'kotti.depot.0.backend': 'kotti.tests.TFS1',
+            'kotti.depot.0.name': 'localfs',
+            'kotti.depot.0.location': '/tmp',
+            'kotti.depot.1.backend': 'kotti.tests.TFS2',
+            'kotti.depot.1.uri': 'mongo://',
+            'kotti.depot.1.name': 'mongo',
         }
 
         # depot.manager.DepotManager acts as singleton, save its settings

--- a/kotti/tests/test_file.py
+++ b/kotti/tests/test_file.py
@@ -20,42 +20,30 @@ class TestFileViews:
 
     def test_inline_view(self, config, filedepot):
         from kotti.views.file import inline_view
-        from kotti.views.file import as_inline
-        from pyramid.response import IResponse
 
         config.include('kotti.views.file')
 
         self._create_file(config)
 
         res = inline_view(self.file, None)
-        assert isinstance(res, as_inline)
-
-        response = IResponse(res)
-        headers = response.headers
+        headers = res.headers
 
         self._test_common_headers(headers)
 
         assert headers["Content-Disposition"] == 'inline;filename="myfle.png"'
-        assert response.app_iter.file.read() == 'file contents'
+        assert res.app_iter.file.read() == 'file contents'
 
     def test_attachment_view(self, config, filedepot):
         from kotti.views.file import attachment_view
-        from kotti.views.file import as_download
-        from pyramid.response import IResponse
-
-        config.include('kotti.views.file')
 
         self._create_file(config)
         res = attachment_view(self.file, None)
-        assert isinstance(res, as_download)
-
-        response = IResponse(res)
-        headers = response.headers
+        headers = res.headers
 
         self._test_common_headers(headers)
         assert headers["Content-Disposition"] == (
             'attachment;filename="myfle.png"')
-        assert response.app_iter.file.read() == 'file contents'
+        assert res.app_iter.file.read() == 'file contents'
 
 
 class TestFileEditForm:

--- a/kotti/tests/test_file.py
+++ b/kotti/tests/test_file.py
@@ -207,7 +207,7 @@ class TestDepotStore:
 
         db_session.add(f)
         db_session.flush()
+        assert id in DepotManager.get()._storage.keys()
         db_session.rollback()
-
-        assert DepotManager.get().delete.called
         assert id not in DepotManager.get()._storage.keys()
+        assert DepotManager.get().delete.called

--- a/kotti/tests/test_file.py
+++ b/kotti/tests/test_file.py
@@ -189,10 +189,3 @@ class TestDepotStore:
         assert DepotManager.get().delete.called
         assert id not in DepotManager.get()._storage.keys()
 
-
-class TestFileSetMetadata:
-
-    def test_it(self, db_session, filedepot):
-        from kotti.resources import File
-        f = File("file contents", u"myfile.png", u"image/png")
-        assert f.filename == u"myfile.png"

--- a/kotti/tests/test_file.py
+++ b/kotti/tests/test_file.py
@@ -207,6 +207,12 @@ class TestUploadedFileResponse:
         resp = UploadedFileResponse(f.data, DummyRequest())
         assert resp.headers['Content-Type'] == 'application/octet-stream'
 
+    def test_guess_content_type(self, filedepot):
+        from kotti.resources import File
+        f = File("file contents", u"file.jpg", None)
+        resp = UploadedFileResponse(f.data, DummyRequest())
+        assert resp.headers['Content-Type'] == 'image/jpeg'
+
     def test_caching(self, filedepot, monkeypatch):
         import datetime
         import webob.response

--- a/kotti/tests/test_file.py
+++ b/kotti/tests/test_file.py
@@ -188,4 +188,3 @@ class TestDepotStore:
 
         assert DepotManager.get().delete.called
         assert id not in DepotManager.get()._storage.keys()
-

--- a/kotti/tests/test_file.py
+++ b/kotti/tests/test_file.py
@@ -206,11 +206,10 @@ class TestDepotStore:
         f = factory(data='file content', name=u'content', title=u'content')
         id = f.data['file_id']
 
-        assert id in DepotManager.get()._storage.keys()
-
         db_session.add(f)
         db_session.flush()
         assert id in DepotManager.get()._storage.keys()
+
         db_session.rollback()
         assert id not in DepotManager.get()._storage.keys()
         assert DepotManager.get().delete.called

--- a/kotti/tests/test_file.py
+++ b/kotti/tests/test_file.py
@@ -18,7 +18,7 @@ class TestFileViews:
         assert headers["Content-Length"] == "13"
         assert headers["Content-Type"] == "image/png"
 
-    def test_inline_view(self, config):
+    def test_inline_view(self, config, filedepot):
         self._create_file(config)
         from kotti.views.file import inline_view
         res = inline_view(self.file, None)
@@ -28,7 +28,7 @@ class TestFileViews:
         assert headers["Content-Disposition"] == 'inline;filename="myfle.png"'
         assert res.body == 'file contents'
 
-    def test_attachment_view(self, config):
+    def test_attachment_view(self, config, filedepot):
         self._create_file(config)
         from kotti.views.file import attachment_view
         res = attachment_view(self.file, None)
@@ -103,7 +103,7 @@ class TestFileAddForm:
         from kotti.views.edit.content import FileAddForm
         return FileAddForm(MagicMock(), DummyRequest())
 
-    def test_add(self, config):
+    def test_add(self, config, filedepot):
         view = self.make_one()
         file = view.add(
             title=u'A title',

--- a/kotti/tests/test_file.py
+++ b/kotti/tests/test_file.py
@@ -19,25 +19,43 @@ class TestFileViews:
         assert headers["Content-Type"] == "image/png"
 
     def test_inline_view(self, config, filedepot):
-        self._create_file(config)
         from kotti.views.file import inline_view
+        from kotti.views.file import as_inline
+        from pyramid.response import IResponse
+
+        config.include('kotti.views.file')
+
+        self._create_file(config)
+
         res = inline_view(self.file, None)
-        headers = res.headers
+        assert isinstance(res, as_inline)
+
+        response = IResponse(res)
+        headers = response.headers
 
         self._test_common_headers(headers)
+
         assert headers["Content-Disposition"] == 'inline;filename="myfle.png"'
-        assert res.body == 'file contents'
+        assert response.app_iter.file.read() == 'file contents'
 
     def test_attachment_view(self, config, filedepot):
-        self._create_file(config)
         from kotti.views.file import attachment_view
+        from kotti.views.file import as_download
+        from pyramid.response import IResponse
+
+        config.include('kotti.views.file')
+
+        self._create_file(config)
         res = attachment_view(self.file, None)
-        headers = res.headers
+        assert isinstance(res, as_download)
+
+        response = IResponse(res)
+        headers = response.headers
 
         self._test_common_headers(headers)
         assert headers["Content-Disposition"] == (
             'attachment;filename="myfle.png"')
-        assert res.body == 'file contents'
+        assert response.app_iter.file.read() == 'file contents'
 
 
 class TestFileEditForm:

--- a/kotti/tests/test_filedepot.py
+++ b/kotti/tests/test_filedepot.py
@@ -12,14 +12,19 @@ class TestDBStoredFile:
 
         assert f.close() is None
         assert f.closed() is False
-        assert f.seekable() is False
+        assert f.seekable() is True
         assert f.writable() is False
 
         assert f.read() == 'content'
+        assert f.read() == ''
+        f.seek(0)
+        assert f.read() == 'content'
+        f.seek(0)
         assert f.read(-1) == 'content'
-        assert f.read(0) == ''
+        f.seek(0)
         assert f.read(2) == 'co'
-        assert f.read(4) == 'cont'
+        assert f.read(4) == 'nten'
+        assert f.tell() == 6
 
         assert f.content_length == 1000
         assert f.content_type == 'image/jpeg'

--- a/kotti/tests/test_filedepot.py
+++ b/kotti/tests/test_filedepot.py
@@ -25,6 +25,10 @@ class TestDBStoredFile:
         assert f.read(2) == 'co'
         assert f.read(4) == 'nten'
         assert f.tell() == 6
+        f.seek(0)
+        f.seek(100)
+        assert f.tell() == 100
+        assert f.read() == ''
 
         assert f.content_length == 1000
         assert f.content_type == 'image/jpeg'

--- a/kotti/tests/test_filedepot.py
+++ b/kotti/tests/test_filedepot.py
@@ -1,0 +1,63 @@
+import datetime
+
+class TestDBStoredFile:
+
+    def test_content_length(self, db_session, events, setup_app):
+        from kotti.filedepot import DBStoredFile
+
+        f = DBStoredFile('fileid', data="content")
+        db_session.add(f)
+        db_session.flush()
+        assert f.content_length == 7
+        f.data = 'content changed'
+        db_session.flush()
+        assert f.content_length == len('content changed')
+
+    def test_last_modified(self, monkeypatch, db_session, events, setup_app):
+        from kotti.filedepot import DBStoredFile
+        from kotti import filedepot
+
+        now = datetime.datetime.now()
+
+        class mockdatetime:
+            @staticmethod
+            def now():
+                return now
+
+        monkeypatch.setattr(filedepot, 'datetime', mockdatetime)
+
+        f = DBStoredFile('fileid', data="content")
+        db_session.add(f)
+        db_session.flush()
+
+        assert f.last_modified == now
+
+        f.last_modified = None
+        f.data = 'content changed'
+        db_session.flush()
+
+        assert f.last_modified == now
+
+    def test_storedfile_interface(self):
+        from kotti.filedepot import DBStoredFile
+
+        f = DBStoredFile('fileid', filename='f.jpg', content_type='image/jpeg',
+                         content_length=1000, data='content')
+
+        assert f.close() == None
+        assert f.closed() == False
+        assert f.seekable() == False
+        assert f.writable() == False
+
+        assert f.read() == 'content'
+        assert f.read(-1) == 'content'
+        assert f.read(0) == ''
+        assert f.read(2) == 'co'
+        assert f.read(4) == 'cont'
+
+        assert f.content_length == 1000
+        assert f.content_type == 'image/jpeg'
+        assert f.file_id == 'fileid'
+        assert f.filename == 'f.jpg'
+        assert f.name == "f.jpg"
+        assert f.public_url == None

--- a/kotti/tests/test_filedepot.py
+++ b/kotti/tests/test_filedepot.py
@@ -99,7 +99,7 @@ class TestDBFileStorage:
 
     def test_get(self, db_session):
         with pytest.raises(IOError):
-            DBFileStorage().get(1)
+            DBFileStorage().get("1")
 
         file_id = self.make_one()
         assert DBFileStorage().get(file_id).data == "content here"

--- a/kotti/tests/test_functional.py
+++ b/kotti/tests/test_functional.py
@@ -36,13 +36,13 @@ class TestUploadFile:
         browser.getControl('save').click()
 
     @user('admin')
-    def test_it(self, browser):
+    def test_it(self, browser, filedepot):
         browser.open(BASE_URL + '/@@add_file')
         self.add_file(browser)
         assert "Item was added" in browser.contents
 
     @user('admin')
-    def test_view_uploaded_file(self, browser):
+    def test_view_uploaded_file(self, browser, filedepot):
         browser.open(BASE_URL + '/@@add_file')
         self.add_file(browser)
         browser.getLink("View").click()
@@ -50,7 +50,7 @@ class TestUploadFile:
         assert browser.contents == 'ABC'
 
     @user('admin')
-    def test_tempstorage(self, browser):
+    def test_tempstorage(self, browser, filedepot):
         browser.open(BASE_URL + '/@@add_file')
         self.add_file(browser, contents='DEF')
         browser.getLink("Edit").click()

--- a/kotti/tests/test_functional.py
+++ b/kotti/tests/test_functional.py
@@ -64,7 +64,7 @@ class TestUploadFile:
         assert browser.contents == 'DEF'
 
     @user('admin')
-    def test_edit_uploaded_file(self, browser):
+    def test_edit_uploaded_file(self, browser, filedepot):
         browser.open(BASE_URL + '/@@add_file')
         self.add_file(browser, contents='GHI')
         browser.getLink("Edit").click()

--- a/kotti/util.py
+++ b/kotti/util.py
@@ -276,6 +276,32 @@ def extract_from_settings(prefix, settings=None):
     return extracted
 
 
+def flatdotted_to_dict(prefix, settings=None):
+    """
+      >>> settings = {
+      ...     'kotti.depot.default.backend': 'local',
+      ...     'kotti.depot.default.file_storage': 'var/files',
+      ...     'kotti.depot.mongo.backend': 'mongodb',
+      ...     'kotti.depot.mongo.uri': 'localhost://',
+      ... }
+      >>> res = flatdotted_to_dict('kotti.depot.', settings)
+      >>> print sorted(res.keys())
+      ['default', 'mongo']
+      >>> print res['default']
+      {'file_storage': 'var/files', 'backend': 'local'}
+      >>> print res['mongo']
+      {'uri': 'localhost://', 'backend': 'mongodb'}
+    """
+
+    extracted = {}
+    for k, v in extract_from_settings(prefix, settings).items():
+        name, conf = k.split('.', 1)
+        extracted.setdefault(name, {})
+        extracted[name][conf] = v
+
+    return extracted
+
+
 def disambiguate_name(name):
     parts = name.split(u'-')
     if len(parts) > 1:

--- a/kotti/util.py
+++ b/kotti/util.py
@@ -7,6 +7,7 @@ Inheritance Diagram
 .. inheritance-diagram:: kotti.util
 """
 
+import cgi
 import re
 import urllib
 from urlparse import urlparse, urlunparse
@@ -365,3 +366,17 @@ deprecated(
     'ViewLink',
     "kotti.util.ViewLink has been renamed to Link as of Kotti 1.0.0."
     )
+
+
+def _to_fieldstorage(fp, filename, mimetype, size, **_kwds):
+    """ Build a cgi.FieldStorage instance.
+
+    Deform's FileUploadWidget returns a dict, but filedepot's
+    UploadedFieldFile likes cgi.FieldStorage objects
+    """
+    f = cgi.FieldStorage()
+    f.file = fp
+    f.filename = filename
+    f.type = mimetype
+    f.length = size
+    return f

--- a/kotti/util.py
+++ b/kotti/util.py
@@ -277,9 +277,9 @@ def extract_from_settings(prefix, settings=None):
     return extracted
 
 
-def flatdotted_to_dict(prefix, settings=None):
+def extract_depot_settings(prefix="kotti.depot.", settings=None):
     """ Merges items from a dictionary that have keys that start with `prefix`
-    to a new dictionary result.
+    to a list of dictionaries.
 
     :param prefix: A dotted string representing the prefix for the common values
     :type prefix: string
@@ -287,27 +287,32 @@ def flatdotted_to_dict(prefix, settings=None):
     :type settings: dict
 
       >>> settings = {
-      ...     'kotti.depot.default.backend': 'local',
-      ...     'kotti.depot.default.file_storage': 'var/files',
-      ...     'kotti.depot.mongo.backend': 'mongodb',
-      ...     'kotti.depot.mongo.uri': 'localhost://',
+      ...     'kotti.depot.0.backend': 'kotti.filedepot.DBFileStorage',
+      ...     'kotti.depot.0.file_storage': 'var/files',
+      ...     'kotti.depot.0.name': 'local',
+      ...     'kotti.depot.1.backend': 'depot.io.gridfs.GridStorage',
+      ...     'kotti.depot.1.name': 'mongodb',
+      ...     'kotti.depot.1.uri': 'localhost://',
       ... }
-      >>> res = flatdotted_to_dict('kotti.depot.', settings)
-      >>> print sorted(res.keys())
-      ['default', 'mongo']
-      >>> print res['default']
-      {'file_storage': 'var/files', 'backend': 'local'}
-      >>> print res['mongo']
-      {'uri': 'localhost://', 'backend': 'mongodb'}
+      >>> res = extract_depot_settings('kotti.depot.', settings)
+      >>> print sorted(res[0].items())
+      [('backend', 'kotti.filedepot.DBFileStorage'), ('file_storage', 'var/files'), ('name', 'local')]
+      >>> print sorted(res[1].items())
+      [('backend', 'depot.io.gridfs.GridStorage'), ('name', 'mongodb'), ('uri', 'localhost://')]
     """
 
     extracted = {}
     for k, v in extract_from_settings(prefix, settings).items():
-        name, conf = k.split('.', 1)
-        extracted.setdefault(name, {})
-        extracted[name][conf] = v
+        index, conf = k.split('.', 1)
+        index = int(index)
+        extracted.setdefault(index, {})
+        extracted[index][conf] = v
 
-    return extracted
+    result = []
+    for k in sorted(extracted.keys()):
+        result.append(extracted[k])
+
+    return result
 
 
 def disambiguate_name(name):

--- a/kotti/util.py
+++ b/kotti/util.py
@@ -278,7 +278,14 @@ def extract_from_settings(prefix, settings=None):
 
 
 def flatdotted_to_dict(prefix, settings=None):
-    """
+    """ Merges items from a dictionary that have keys that start with `prefix`
+    to a new dictionary result.
+
+    :param prefix: A dotted string representing the prefix for the common values
+    :type prefix: string
+    :value settings: A dictionary with settings. Result is extracted from this
+    :type settings: dict
+
       >>> settings = {
       ...     'kotti.depot.default.backend': 'local',
       ...     'kotti.depot.default.file_storage': 'var/files',
@@ -369,10 +376,11 @@ deprecated(
 
 
 def _to_fieldstorage(fp, filename, mimetype, size, **_kwds):
-    """ Build a cgi.FieldStorage instance.
+    """ Build a :class:`cgi.FieldStorage` instance.
 
-    Deform's FileUploadWidget returns a dict, but filedepot's
-    UploadedFieldFile likes cgi.FieldStorage objects
+    Deform's :class:`FileUploadWidget` returns a dict, but
+    :class:`depot.fields.sqlalchemy.UploadedFileField` likes
+    :class:`cgi.FieldStorage` objects
     """
     f = cgi.FieldStorage()
     f.file = fp

--- a/kotti/views/edit/content.py
+++ b/kotti/views/edit/content.py
@@ -16,6 +16,7 @@ from kotti.resources import Document
 from kotti.resources import File
 from kotti.resources import Image
 from kotti.util import _
+from kotti.util import _to_fieldstorage
 from kotti.views.form import get_appstruct
 from kotti.views.form import AddFormView
 from kotti.views.form import EditFormView
@@ -102,18 +103,7 @@ class FileEditForm(EditFormView):
         self.context.description = appstruct['description']
         self.context.tags = appstruct['tags']
         if appstruct['file']:
-            buf = appstruct['file']['fp']
-            size = 0
-            while True:
-                chunk = buf.read(1024)
-                if not chunk:
-                    break
-                size += len(chunk)
-            buf.seek(0)
-            self.context.data = buf
-            self.context.filename = appstruct['file']['filename']
-            self.context.mimetype = appstruct['file']['mimetype']
-            self.context.size = size
+            self.context.data = _to_fieldstorage(**appstruct['file'])
 
 
 class FileAddForm(AddFormView):
@@ -130,23 +120,12 @@ class FileAddForm(AddFormView):
         return super(FileAddForm, self).save_success(appstruct)
 
     def add(self, **appstruct):
-        buf = appstruct['file']['fp']
-        size = 0
-        while True:
-            chunk = buf.read(1024)
-            if not chunk:
-                break
-            size += len(chunk)
-        buf.seek(0)
         filename = appstruct['file']['filename']
         item = self.item_class(
             title=appstruct['title'] or filename,
             description=appstruct['description'],
             tags=appstruct['tags'],
-            data=buf,
-            filename=filename,
-            mimetype=appstruct['file']['mimetype'],
-            size=size,
+            data=_to_fieldstorage(**appstruct['file']),
         )
         return item
 

--- a/kotti/views/edit/content.py
+++ b/kotti/views/edit/content.py
@@ -147,7 +147,7 @@ class FileAddForm(AddFormView):
             filename=filename,
             mimetype=appstruct['file']['mimetype'],
             size=size,
-            )
+        )
         return item
 
 

--- a/kotti/views/edit/content.py
+++ b/kotti/views/edit/content.py
@@ -130,7 +130,7 @@ class FileAddForm(AddFormView):
         return super(FileAddForm, self).save_success(appstruct)
 
     def add(self, **appstruct):
-        buf = appstruct['file']['fp']   #.read()
+        buf = appstruct['file']['fp']
         size = 0
         while True:
             chunk = buf.read(1024)
@@ -148,7 +148,6 @@ class FileAddForm(AddFormView):
             mimetype=appstruct['file']['mimetype'],
             size=size,
             )
-        import pdb; pdb.set_trace()
         return item
 
 

--- a/kotti/views/file.py
+++ b/kotti/views/file.py
@@ -38,6 +38,7 @@ class UploadedFileResponse(Response):
                  content_encoding=None):
 
         filename = data.filename
+        content_type = content_type or getattr(data, 'content_type', None)
 
         if content_type is None:
             content_type, content_encoding = mimetypes.guess_type(

--- a/kotti/views/file.py
+++ b/kotti/views/file.py
@@ -22,7 +22,7 @@ def inline_view(context, request, disposition='inline'):
             ('Content-Type', str(context.mimetype)),
             ]
         )
-    res.body = context.data
+    res.body = context.data.file.read()
     return res
 
 

--- a/kotti/views/file.py
+++ b/kotti/views/file.py
@@ -38,8 +38,8 @@ class UploadedFileResponse(Response):
                  content_encoding=None):
 
         filename = data.filename
-        content_type = content_type or getattr(data, 'content_type', None)
 
+        content_type = content_type or getattr(data, 'content_type', None)
         if content_type is None:
             content_type, content_encoding = mimetypes.guess_type(
                 filename,
@@ -47,10 +47,10 @@ class UploadedFileResponse(Response):
                 )
             if content_type is None:
                 content_type = 'application/octet-stream'
-            # str-ifying content_type is a workaround for a bug in Python 2.7.7
-            # on Windows where mimetypes.guess_type returns unicode for the
-            # content_type.
-            content_type = str(content_type)
+        # str-ifying content_type is a workaround for a bug in Python 2.7.7
+        # on Windows where mimetypes.guess_type returns unicode for the
+        # content_type.
+        content_type = str(content_type)
 
         super(UploadedFileResponse, self).__init__(
             conditional_response=True,

--- a/kotti/views/file.py
+++ b/kotti/views/file.py
@@ -73,66 +73,6 @@ class UploadedFileResponse(Response):
         self.headerlist.append(('Content-Disposition', disp))
 
 
-class as_inline(object):
-    """ ``UploadedFile`` adapter for an inline content-disposition Response
-
-    Writing a view to inline view a file (such as an image) can be as easy as::
-
-        @view_config(name='image', context=Image, permission='View')
-        def view_image(context, request):
-            return as_inline(context.imagefield)
-    """
-
-    def __init__(self, data, request):
-        """
-        :param data: :A file field obtained by reading an
-                        :class:`~depot.fields.sqlalchemy.UploadedFileField`
-        :type data: :class:`depot.fields.upload.UploadedField`,
-
-        :param request: current request
-        :type request: :class:`pyramid.request.Request`
-        """
-        self.data = data
-        self.request = request
-
-
-class as_download(object):
-    """ ``UploadedFile`` adapter for an attachment content-disposition Response
-
-    Writing a view to download a file can be as easy as::
-
-        @view_config(name='image', context=Image, permission='View')
-        def download(context, request):
-            return as_download(context.filefield)
-    """
-
-    def __init__(self, data, request):
-        """
-        :param data: :A file field obtained by reading an
-                        :class:`~depot.fields.sqlalchemy.UploadedFileField`
-        :type data: :class:`depot.fields.upload.UploadedField`,
-
-        :param request: current request
-        :type request: :class:`pyramid.request.Request`
-        """
-        self.data = data
-        self.request = request
-
-
-@response_adapter(as_download)
-def field_to_download_response(adapter):
-    return UploadedFileResponse(adapter.data,
-                                request=adapter.request,
-                                disposition='attachment')
-
-
-@response_adapter(as_inline)
-def field_to_inline_response(adapter):
-    return UploadedFileResponse(adapter.data,
-                                request=adapter.request,
-                                disposition='inline')
-
-
 @view_config(name='view', context=File, permission='view',
              renderer='kotti:templates/view/file.pt')
 def view(context, request):

--- a/kotti/views/file.py
+++ b/kotti/views/file.py
@@ -34,9 +34,11 @@ class UploadedFileResponse(Response):
     Code adapted from pyramid.response.FileResponse
     """
     def __init__(self, data, request=None, disposition='attachment',
-                 cache_max_age=None, content_type=None, content_encoding=None):
+                 cache_max_age=None, content_type=None,
+                 content_encoding=None):
 
         filename = data.filename
+
         if content_type is None:
             content_type, content_encoding = mimetypes.guess_type(
                 filename,
@@ -48,24 +50,17 @@ class UploadedFileResponse(Response):
             # on Windows where mimetypes.guess_type returns unicode for the
             # content_type.
             content_type = str(content_type)
+
         super(UploadedFileResponse, self).__init__(
             conditional_response=True,
             content_type=content_type,
             content_encoding=content_encoding
         )
-        self.last_modified = data.file.last_modified
-        content_length = data.file.content_length
-        f = data.file
-        app_iter = None
-        if request is not None:
-            environ = request.environ
-            if 'wsgi.file_wrapper' in environ:
-                app_iter = environ['wsgi.file_wrapper'](f, _BLOCK_SIZE)
-        if app_iter is None:
-            app_iter = FileIter(f, _BLOCK_SIZE)
-        self.app_iter = app_iter
+
+        self.app_iter = FileIter(data.file, _BLOCK_SIZE)
         # assignment of content_length must come after assignment of app_iter
-        self.content_length = content_length
+        self.content_length = data.file.content_length
+        self.last_modified = data.file.last_modified
         if cache_max_age is not None:
             self.cache_expires = cache_max_age
 

--- a/kotti/views/file.py
+++ b/kotti/views/file.py
@@ -2,7 +2,6 @@
 
 from pyramid.response import _BLOCK_SIZE
 from pyramid.response import FileIter
-from pyramid.response import response_adapter
 from pyramid.response import Response
 from pyramid.view import view_config
 
@@ -133,7 +132,6 @@ def field_to_inline_response(adapter):
     return UploadedFileResponse(adapter.data,
                                 request=adapter.request,
                                 disposition='inline')
->>>>>>> Use a file iterator for file downloading
 
 
 @view_config(name='view', context=File, permission='view',
@@ -143,13 +141,13 @@ def view(context, request):
 
 
 @view_config(name='inline-view', context=File, permission='view')
-def inline_view(context, request, disposition='inline'):
-    return as_inline(context.data, request)
+def inline_view(context, request):
+    return UploadedFileResponse(context.data, request, disposition='inline')
 
 
 @view_config(name='attachment-view', context=File, permission='view')
 def attachment_view(context, request):
-    return as_download(context.data, request)
+    return UploadedFileResponse(context.data, request, disposition='attachment')
 
 
 def includeme(config):

--- a/kotti/views/file.py
+++ b/kotti/views/file.py
@@ -1,9 +1,139 @@
 # -*- coding: utf-8 -*-
 
+from pyramid.response import _BLOCK_SIZE
+from pyramid.response import FileIter
+from pyramid.response import response_adapter
 from pyramid.response import Response
 from pyramid.view import view_config
 
 from kotti.resources import File
+
+import mimetypes
+
+
+class UploadedFileResponse(Response):
+    """
+    A Response object that can be used to serve a uploaded files.
+
+    ``data`` is the ``UploadedFile`` file field value.
+
+    ``request`` must be a Pyramid :term:`request` object.  Note
+    that a request *must* be passed if the response is meant to attempt to
+    use the ``wsgi.file_wrapper`` feature of the web server that you're using
+    to serve your Pyramid application.
+
+    ``cache_max_age`` is the number of seconds that should be used
+    to HTTP cache this response.
+
+    ``content_type`` is the content_type of the response.
+
+    ``content_encoding`` is the content_encoding of the response.
+    It's generally safe to leave this set to ``None`` if you're serving a
+    binary file.  This argument will be ignored if you also leave
+    ``content-type`` as ``None``.
+
+    Code adapted from pyramid.response.FileResponse
+    """
+    def __init__(self, data, request=None, disposition='attachment',
+                 cache_max_age=None, content_type=None, content_encoding=None):
+
+        filename = data.filename
+        if content_type is None:
+            content_type, content_encoding = mimetypes.guess_type(
+                filename,
+                strict=False
+                )
+            if content_type is None:
+                content_type = 'application/octet-stream'
+            # str-ifying content_type is a workaround for a bug in Python 2.7.7
+            # on Windows where mimetypes.guess_type returns unicode for the
+            # content_type.
+            content_type = str(content_type)
+        super(UploadedFileResponse, self).__init__(
+            conditional_response=True,
+            content_type=content_type,
+            content_encoding=content_encoding
+        )
+        self.last_modified = data.file.last_modified
+        content_length = data.file.content_length
+        f = data.file
+        app_iter = None
+        if request is not None:
+            environ = request.environ
+            if 'wsgi.file_wrapper' in environ:
+                app_iter = environ['wsgi.file_wrapper'](f, _BLOCK_SIZE)
+        if app_iter is None:
+            app_iter = FileIter(f, _BLOCK_SIZE)
+        self.app_iter = app_iter
+        # assignment of content_length must come after assignment of app_iter
+        self.content_length = content_length
+        if cache_max_age is not None:
+            self.cache_expires = cache_max_age
+
+        disp = '%s;filename="%s"' % (disposition,
+                                     data.filename.encode('ascii', 'ignore'))
+        self.headerlist.append(('Content-Disposition', disp))
+
+
+class as_inline(object):
+    """ ``UploadedFile`` adapter for an inline content-disposition Response
+
+    Writing a view to inline view a file (such as an image) can be as easy as::
+
+        @view_config(name='image', context=Image, permission='View')
+        def view_image(context, request):
+            return as_inline(context.imagefield)
+    """
+
+    def __init__(self, data, request):
+        """
+        :param data: :A file field obtained by reading an
+                        :class:`~depot.fields.sqlalchemy.UploadedFileField`
+        :type data: :class:`depot.fields.upload.UploadedField`,
+
+        :param request: current request
+        :type request: :class:`pyramid.request.Request`
+        """
+        self.data = data
+        self.request = request
+
+
+class as_download(object):
+    """ ``UploadedFile`` adapter for an attachment content-disposition Response
+
+    Writing a view to download a file can be as easy as::
+
+        @view_config(name='image', context=Image, permission='View')
+        def download(context, request):
+            return as_download(context.filefield)
+    """
+
+    def __init__(self, data, request):
+        """
+        :param data: :A file field obtained by reading an
+                        :class:`~depot.fields.sqlalchemy.UploadedFileField`
+        :type data: :class:`depot.fields.upload.UploadedField`,
+
+        :param request: current request
+        :type request: :class:`pyramid.request.Request`
+        """
+        self.data = data
+        self.request = request
+
+
+@response_adapter(as_download)
+def field_to_download_response(adapter):
+    return UploadedFileResponse(adapter.data,
+                                request=adapter.request,
+                                disposition='attachment')
+
+
+@response_adapter(as_inline)
+def field_to_inline_response(adapter):
+    return UploadedFileResponse(adapter.data,
+                                request=adapter.request,
+                                disposition='inline')
+>>>>>>> Use a file iterator for file downloading
 
 
 @view_config(name='view', context=File, permission='view',
@@ -12,24 +142,14 @@ def view(context, request):
     return {}
 
 
-@view_config(name='inline-view', context=File,
-             permission='view')
+@view_config(name='inline-view', context=File, permission='view')
 def inline_view(context, request, disposition='inline'):
-    res = Response(
-        headerlist=[
-            ('Content-Disposition', '%s;filename="%s"' % (
-                disposition, context.filename.encode('ascii', 'ignore'))),
-            ('Content-Type', str(context.mimetype)),
-            ]
-        )
-    res.body = context.data.file.read()
-    return res
+    return as_inline(context.data, request)
 
 
-@view_config(name='attachment-view', context=File,
-             permission='view')
+@view_config(name='attachment-view', context=File, permission='view')
 def attachment_view(context, request):
-    return inline_view(context, request, 'attachment')
+    return as_download(context.data, request)
 
 
 def includeme(config):

--- a/kotti/views/image.py
+++ b/kotti/views/image.py
@@ -93,9 +93,9 @@ class ImageView(object):
                 self.context.data, self.request, disposition)
 
         image, format, size = scaleImage(self.context.data.file.read(),
-                                            width=width,
-                                            height=height,
-                                            direction="thumb")
+                                         width=width,
+                                         height=height,
+                                         direction="thumb")
         res = Response(
             headerlist=[('Content-Disposition', '%s;filename="%s"' % (
                 disposition,

--- a/kotti/views/image.py
+++ b/kotti/views/image.py
@@ -88,12 +88,12 @@ class ImageView(object):
                 width, height = image_scales[scale]
 
         if width and height:
-            image, format, size = scaleImage(self.context.data,
+            image, format, size = scaleImage(self.context.data.file.read(),
                                              width=width,
                                              height=height,
                                              direction="thumb")
         else:
-            image = self.context.data
+            image = self.context.data.file.read()
 
         res = Response(
             headerlist=[('Content-Disposition', '%s;filename="%s"' % (

--- a/kotti/views/image.py
+++ b/kotti/views/image.py
@@ -10,6 +10,7 @@ from pyramid.view import view_defaults
 
 from kotti.interfaces import IImage
 from kotti.util import extract_from_settings
+from kotti.views.file import UploadedFileResponse
 
 PIL.ImageFile.MAXBLOCK = 33554432
 
@@ -87,14 +88,14 @@ class ImageView(object):
                 # /path/to/image/scale/thumb
                 width, height = image_scales[scale]
 
-        if width and height:
-            image, format, size = scaleImage(self.context.data.file.read(),
-                                             width=width,
-                                             height=height,
-                                             direction="thumb")
-        else:
-            image = self.context.data.file.read()
+        if not (width and height):
+            return UploadedFileResponse(
+                self.context.data, self.request, disposition)
 
+        image, format, size = scaleImage(self.context.data.file.read(),
+                                            width=width,
+                                            height=height,
+                                            direction="thumb")
         res = Response(
             headerlist=[('Content-Disposition', '%s;filename="%s"' % (
                 disposition,
@@ -103,7 +104,7 @@ class ImageView(object):
                 ('Content-Type', str(self.context.mimetype)),
             ],
             body=image,
-            )
+        )
 
         return res
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Kotti==1.0.0-alpha.4
--e git+ssh://git@github.com/amol-/depot.git#egg=filedepot
-
+filedepot==0.0.2
 Babel==1.3
 Beaker==1.6.4
 Chameleon==2.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 Kotti==1.0.0-alpha.4
+-e git+ssh://git@github.com/amol-/depot.git#egg=filedepot
+
 Babel==1.3
 Beaker==1.6.4
 Chameleon==2.20

--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,7 @@ setup(name='Kotti',
       [console_scripts]
       kotti-migrate = kotti.migrate:kotti_migrate_command
       kotti-reset-workflow = kotti.workflow:reset_workflow_command
+      kotti-migrate-storage = kotti.filedepot:migrate_storages_command
 
       [pytest11]
       kotti = kotti.tests


### PR DESCRIPTION


@tiberiuichim writes: 
Open issues:

- [x] No work done on UploadedFile.public_url integration, this means that filedepot's middleware is not usable right now - because no links are generated that would use it. I have created the UploadedFileResponse class which can be used to stream files to the browser. I don't think that we should make the middleware a default for Kotti, that would mean all files are openly available, without any security. An option would be to use the UploadedFileResponse to send a redirection to the public_url, where it is set by the depot that stores the files. The problem is, the proper filedepot way to get a file's url is to call DepotManager.url_for(path), which calls DepotManager.get_middleware().url_for(path) where path is 'depotname/file_id'.

- [x] We need a kotti.depot_default configuration option. I'm not sattisfied with the way things are now: we're adding the default 'fs0' depot, but once in use, you can't change its backend (or those files would stop working without a migration). Because I've added that option to kotti's conf_defaults, you can't really get rid of it anyway - you can only change its backend class by adding another kotti.depot.fs0.backend option in the .ini file. I have assumed that the default for multiple configured backends could be controlled by the order in which they are specified in the .ini files, but it seems that pyramid likes to sort the settings, so that can't be relied.

- [x] Maybe the File.data column should be renamed to File._data. This way we can have a setter for it and do the conversion to cgi.FieldStorage for the incoming data

- The following documentation sections need changes and updates:

- [x] Configuration http://diskotti.readthedocs.org/en/feature-rtd_theme_339/developing/basic/configuration.html

- [x] Blob-Storage http://diskotti.readthedocs.org/en/feature-rtd_theme_339/developing/advanced/blobstorage.html

- [x] Maybe a separate entry in the Developer manual, detailing how to create and serve new blob fields.