### PR TITLE
Using an addon product with config.add_request_method breaks default views

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,15 @@ Change History
 
 - No changes yet.
 
+1.0.0-alpha.3 - 2015-01-13
+--------------------------
+
+- Explicitly implement ``pyramid.interfaces.IRequest`` for
+  ``kotti.request.Request``.  This allows add-on packages to use
+  ``config.add_request_method`` (with reify) and
+  ``config.add_request_property`` without breaking the interfaces provided by
+  the request. Fixes #369
+
 1.0.0-alpha.2 - 2015-01-01
 --------------------------
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -100,3 +100,4 @@ Contributors
 - Fabien Castarède, 2013/08/08
 - Natan Žabkar, 2013/08/28
 - Ionică Bizău, 2014/04/09
+- Ichim Tiberiu, 2015/01/13

--- a/kotti/request.py
+++ b/kotti/request.py
@@ -47,3 +47,11 @@ class Request(BaseRequest):
 
         with authz_context(context, self):
             return BaseRequest.has_permission(self, permission, context)
+
+
+# workaround for https://github.com/Pylons/pyramid/issues/1529
+# this allows addon packages to call config.add_request_method and not lose
+# the interfaces provided by the request (for example to call a subview,
+# like kotti.view.view_content_default)
+from zope.interface import providedBy
+providedBy(Request({}))

--- a/kotti/request.py
+++ b/kotti/request.py
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
 
+from zope.interface import implementer
+
 from pyramid.decorator import reify
+from pyramid.interfaces import IRequest
 from pyramid.request import Request as BaseRequest
 
 
+@implementer(IRequest)
 class Request(BaseRequest):
     """ Kotti subclasses :class:`pyramid.request.Request` to make additional
     attributes / methods available on request objects and override Pyramid's
@@ -47,11 +51,3 @@ class Request(BaseRequest):
 
         with authz_context(context, self):
             return BaseRequest.has_permission(self, permission, context)
-
-
-# workaround for https://github.com/Pylons/pyramid/issues/1529
-# this allows addon packages to call config.add_request_method and not lose
-# the interfaces provided by the request (for example to call a subview,
-# like kotti.view.view_content_default)
-from zope.interface import providedBy
-providedBy(Request({}))

--- a/kotti/tests/test_request.py
+++ b/kotti/tests/test_request.py
@@ -5,7 +5,7 @@ class TestExtendingRequest:
         from zope.interface import providedBy, implementedBy
 
         req = Request({})
-        req._set_properties({'marker':'exists'})
+        req._set_properties({'marker': 'exists'})
 
         assert providedBy(req) == implementedBy(Request)
         assert req.marker == 'exists'

--- a/kotti/tests/test_request.py
+++ b/kotti/tests/test_request.py
@@ -1,0 +1,56 @@
+from pyramid.config import Configurator
+from pyramid.threadlocal import manager, get_current_registry
+from pyramid.view import render_view_to_response
+from pyramid.response import Response
+
+from kotti.request import Request
+from kotti.resources import Document
+
+
+class TestRequest:
+
+    def _make_request(self, name):
+        environ = {
+            'PATH_INFO': '/',
+            'SERVER_NAME': 'example.com',
+            'SERVER_PORT': '5432',
+            'QUERY_STRING': '',
+            'wsgi.url_scheme': 'http',
+            }
+
+        request = Request(environ)
+        request.view_name = name
+        registry = get_current_registry()
+        request.registry = registry
+        manager.clear()
+        manager.push({'request':request, 'registry':registry})
+
+        return request
+
+    def test_can_reify(self, root, setup_app):
+
+        registry = setup_app.registry
+        config = Configurator(registry,
+                              request_factory='kotti.request.Request')
+        manager.push({'registry':config.registry})
+
+        config.add_view(lambda context, request:Response('first'),
+                        name='view',
+                        context=Document)
+        config.commit()
+
+        response = render_view_to_response(
+            Document(), self._make_request('view1'), name='', secure=False)
+        assert response.body == 'first'
+
+        def view2(context, request):
+            assert request.req_method == 'has it'
+            return Response("second")
+
+        config.add_request_method(lambda req:'has it', 'req_method', reify=True)
+        config.add_view(view2, name='view', context=Document)
+        config.commit()
+
+        response = render_view_to_response(
+            Document(), self._make_request('view2'), name='', secure=False)
+        assert response.body == 'second'

--- a/kotti/tests/test_request.py
+++ b/kotti/tests/test_request.py
@@ -1,31 +1,11 @@
-class TestPyramidRequestProperties:
+class TestExtendingRequest:
 
     def test_it(self):
-        from pyramid.request import Request
+        from kotti.request import Request
         from zope.interface import providedBy, implementedBy
 
         req = Request({})
-        assert providedBy(req) == implementedBy(Request)
-
-        req._set_properties({'b':'b'})
+        req._set_properties({'marker':'exists'})
 
         assert providedBy(req) == implementedBy(Request)
-
-    def test_subclassing(self):
-        from pyramid.request import Request
-        from zope.interface import providedBy, implementedBy
-
-        class Subclass(Request):
-            pass
-
-        req = Subclass({})
-
-        req._set_properties({'b':'b'})
-        assert providedBy(req) != implementedBy(Subclass)
-
-        #calling providedBy(req) before _set_properties makes the test pass
-        req = Subclass({})
-        req._set_properties({'b':'b'})
-        providedBy(req)
-        assert providedBy(req) == implementedBy(Subclass)
-
+        assert req.marker == 'exists'

--- a/kotti/tests/test_request.py
+++ b/kotti/tests/test_request.py
@@ -1,56 +1,31 @@
-from pyramid.config import Configurator
-from pyramid.threadlocal import manager, get_current_registry
-from pyramid.view import render_view_to_response
-from pyramid.response import Response
+class TestPyramidRequestProperties:
 
-from kotti.request import Request
-from kotti.resources import Document
+    def test_it(self):
+        from pyramid.request import Request
+        from zope.interface import providedBy, implementedBy
 
+        req = Request({})
+        assert providedBy(req) == implementedBy(Request)
 
-class TestRequest:
+        req._set_properties({'b':'b'})
 
-    def _make_request(self, name):
-        environ = {
-            'PATH_INFO': '/',
-            'SERVER_NAME': 'example.com',
-            'SERVER_PORT': '5432',
-            'QUERY_STRING': '',
-            'wsgi.url_scheme': 'http',
-            }
+        assert providedBy(req) == implementedBy(Request)
 
-        request = Request(environ)
-        request.view_name = name
-        registry = get_current_registry()
-        request.registry = registry
-        manager.clear()
-        manager.push({'request':request, 'registry':registry})
+    def test_subclassing(self):
+        from pyramid.request import Request
+        from zope.interface import providedBy, implementedBy
 
-        return request
+        class Subclass(Request):
+            pass
 
-    def test_can_reify(self, root, setup_app):
+        req = Subclass({})
 
-        registry = setup_app.registry
-        config = Configurator(registry,
-                              request_factory='kotti.request.Request')
-        manager.push({'registry':config.registry})
+        req._set_properties({'b':'b'})
+        assert providedBy(req) != implementedBy(Subclass)
 
-        config.add_view(lambda context, request:Response('first'),
-                        name='view',
-                        context=Document)
-        config.commit()
+        #calling providedBy(req) before _set_properties makes the test pass
+        req = Subclass({})
+        req._set_properties({'b':'b'})
+        providedBy(req)
+        assert providedBy(req) == implementedBy(Subclass)
 
-        response = render_view_to_response(
-            Document(), self._make_request('view1'), name='', secure=False)
-        assert response.body == 'first'
-
-        def view2(context, request):
-            assert request.req_method == 'has it'
-            return Response("second")
-
-        config.add_request_method(lambda req:'has it', 'req_method', reify=True)
-        config.add_view(view2, name='view', context=Document)
-        config.commit()
-
-        response = render_view_to_response(
-            Document(), self._make_request('view2'), name='', secure=False)
-        assert response.body == 'second'


### PR DESCRIPTION
This is a test and a workaround for a problem described here: https://github.com/Pylons/pyramid/issues/1529

For Kotti it means that including a package such as pyramid_redis, which does ``config.add_request_method(..., reify=True)`` will break all "subrequests", such as the default views rendered by ``kotti.views.view.view_content_default``, because the "subviews" are not found anymore through adapter lookup.