### PR TITLE
Improve title_to_name handling of numbers in titles

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,11 @@ Change History
 
 - No changes yet.
 
+1.0.0-alpha.4 - unreleased
+--------------------------
+- For documents with duplicate titles that end in a number, append a counter 
+  instead of incrementing their number. Fixes #245
+
 1.0.0-alpha.3 - 2015-01-13
 --------------------------
 

--- a/kotti/tests/test_util.py
+++ b/kotti/tests/test_util.py
@@ -74,13 +74,15 @@ class TestTitleToName:
     def test_numbering(self):
         self.setUp()
         from kotti.util import title_to_name
-        assert title_to_name(u'Report Part 1', blacklist=[]) == u'report-part-1'
+        assert title_to_name(u'Report Part 1',
+                             blacklist=[]) == u'report-part-1'
         assert title_to_name(u'Report Part 1',
                              blacklist=['report-part-1']) == u'report-part-1-1'
         assert title_to_name(u'Report Part 3',
-                             blacklist=['report-part-2']) == u'report-part-3'
-        assert title_to_name(u'Report Part 3',
                              blacklist=['report-part-3']) == u'report-part-3-1'
+        assert title_to_name(
+            u'Report Part 3', blacklist=['report-part-3', 'report-part-3-1']
+        ) == u'report-part-3-2'
 
     def test_disambiguate_name(self):
         from kotti.util import disambiguate_name

--- a/kotti/tests/test_util.py
+++ b/kotti/tests/test_util.py
@@ -71,6 +71,17 @@ class TestTitleToName:
         from kotti.util import title_to_name
         assert title_to_name(u'Foo Bar') == u'foo-bar'
 
+    def test_numbering(self):
+        self.setUp()
+        from kotti.util import title_to_name
+        assert title_to_name(u'Report Part 1', blacklist=[]) == u'report-part-1'
+        assert title_to_name(u'Report Part 1',
+                             blacklist=['report-part-1']) == u'report-part-1-1'
+        assert title_to_name(u'Report Part 3',
+                             blacklist=['report-part-2']) == u'report-part-3'
+        assert title_to_name(u'Report Part 3',
+                             blacklist=['report-part-3']) == u'report-part-3-1'
+
     def test_disambiguate_name(self):
         from kotti.util import disambiguate_name
         assert disambiguate_name(u'foo') == u'foo-1'

--- a/kotti/util.py
+++ b/kotti/util.py
@@ -299,6 +299,9 @@ def title_to_name(title, blacklist=()):
     from kotti import get_settings
     urlnormalizer = get_settings()['kotti.url_normalizer'][0]
     name = unicode(urlnormalizer(title, locale_name, max_length=40))
+    if name not in blacklist:
+        return name
+    name += u'-1'
     while name in blacklist:
         name = disambiguate_name(name)
     return name


### PR DESCRIPTION
For documents with duplicate titles that end in a number, append a counter instead of incrementing their number.
Fixes #245