### PR TITLE
installation.rst: Remove `pip install Kotti` step

### DIFF
--- a/docs/first_steps/installation.rst
+++ b/docs/first_steps/installation.rst
@@ -22,8 +22,7 @@ It is recommended to install Kotti inside a virtualenv:
   virtualenv mysite
   cd mysite
   bin/pip install -r https://raw.github.com/Kotti/Kotti/stable/requirements.txt
-  bin/pip install [--pre] Kotti
-
+  
 This will install the latest released version of Kotti and all its requirements into your virtualenv.
 
 Kotti uses `Paste Deploy`_ for configuration and deployment.


### PR DESCRIPTION
It seems to be not necessary as previous command installs Kotti.

```
❯ bin/pip install -r https://raw.github.com/Kotti/Kotti/stable/requirements.txt
...

❯ pip install Kotti
Requirement already satisfied (use --upgrade to upgrade): Kotti in ./lib/python2.7/site-packages
...

❯ pip list | grep Kotti
Kotti (1.0.0-alpha.3)