### PR TITLE
.travis.yml: Set sudo false for new containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 python:
   - "2.6"
   - "2.7"


### PR DESCRIPTION
This makes Travis use a new Docker-based infrastructure that is supposed to be faster and awesomer.

Maybe it will solve the networking-related test failures I keep seeing?