### PR TITLE
Make default view show child nodes

### DIFF
--- a/kotti/templates/view/document.pt
+++ b/kotti/templates/view/document.pt
@@ -10,6 +10,21 @@
     <div tal:replace="api.render_template('kotti:templates/view/tags.pt')" />
     <div class="body" tal:content="structure context.body | None">
     </div>
+    <h2>Children (${len(context.children_with_permission(request))})</h2>
+    <ul>
+        <li tal:repeat="child context.children_with_permission(request)">
+          <a href="${request.resource_url(child)}"
+             title="${getattr(child, 'description', None)}">
+            ${child.title}
+          </a>
+          <a
+             href="${api.url(child, '@@edit')}"
+             title="Edit" i18n:attributes="title">
+            <i class="glyphicon glyphicon-edit"></i>
+          </a>
+        </li>
+    </ul>
+
   </article>
 
 </html>


### PR DESCRIPTION
This is useful for navigation, without having to go to the "Contents" view.

See screenshot below:

![screen shot 2015-01-21 at 11 01 01 am](https://cloud.githubusercontent.com/assets/305268/5842852/1aa5a6f0-a15d-11e4-8e08-70eadf804a24.png)
