### PR TITLE
Add option to make default view show child nodes

### DIFF
--- a/kotti/resources.py
+++ b/kotti/resources.py
@@ -511,6 +511,7 @@ default_type_info = TypeInfo(
     selectable_default_views=[
         ("folder_view", _(u"Folder view")),
         ],
+    default_view_show_children=False,
     )
 
 

--- a/kotti/templates/view/document.pt
+++ b/kotti/templates/view/document.pt
@@ -10,6 +10,23 @@
     <div tal:replace="api.render_template('kotti:templates/view/tags.pt')" />
     <div class="body" tal:content="structure context.body | None">
     </div>
+    <div tal:condition="context.type_info.default_view_show_children">
+        <h2>Children (${len(context.children_with_permission(request))})</h2>
+        <ul>
+            <li tal:repeat="child context.children_with_permission(request)">
+              <a href="${request.resource_url(child)}"
+                 title="${getattr(child, 'description', None)}">
+                ${child.title}
+              </a>
+              <a
+                 href="${api.url(child, '@@edit')}"
+                 title="Edit" i18n:attributes="title">
+                <i class="glyphicon glyphicon-edit"></i>
+              </a>
+            </li>
+        </ul>
+    </div>
+
   </article>
 
 </html>


### PR DESCRIPTION
This is useful for navigation, without having to go to the "Contents" view.

It's turned off by default but can be turned on by setting `default_view_show_children=True` in the resource's `type_info`.

This is similar to #380, which was closed, but I'm wondering if adding configurability makes it more palatable.