### PR TITLE
Default view can show extra columns

### DIFF
--- a/kotti/resources.py
+++ b/kotti/resources.py
@@ -511,6 +511,8 @@ default_type_info = TypeInfo(
     selectable_default_views=[
         ("folder_view", _(u"Folder view")),
         ],
+    default_view_columns=[],
+    default_view_show_children=False,
     )
 
 

--- a/kotti/templates/view/document.pt
+++ b/kotti/templates/view/document.pt
@@ -10,6 +10,15 @@
     <div tal:replace="api.render_template('kotti:templates/view/tags.pt')" />
     <div class="body" tal:content="structure context.body | None">
     </div>
+    <table id="view-table" class="table table-condensed table-striped" tal:condition="context.type_info.default_view_columns">
+        <tbody>
+            <tr tal:repeat="column_tuple context.type_info.default_view_columns">
+                <td>${column_tuple[0]}</td>
+                <td>${getattr(context, column_tuple[1])}</td>
+            </tr>
+        </tbody>
+    </table>
+
   </article>
 
 </html>


### PR DESCRIPTION
by setting `default_view_columns` in the resource's `type_info`. It should be list or tuple with pairs `(human_readable_display_name, model_column_name)`.

```python
        default_view_columns=[
            (_(u"Code name"), 'code_name'),
            (_(u"URL"), 'url'),
            (_(u"Release date"), 'release_date'),
            (_(u"EOL date"), 'eol_date'),
        ]
```

This results in the view including a table that looks like this:
 
![screen shot kotti default view with table with columns](https://cloud.githubusercontent.com/assets/305268/5868246/bcc3f7da-a25b-11e4-90e8-62c12c197e03.png)
