### PR TITLE
Add __json__ method for core types

### DIFF
--- a/kotti/resources.py
+++ b/kotti/resources.py
@@ -310,6 +310,27 @@ class Node(Base, ContainerMixin, PersistentACLMixin):
 
         return copy
 
+    def __json__(self, request):
+        d = {
+            'id': self.id,
+            'type': self.type,
+            'position': self.position,
+            'name': self.name,
+            'title': self.title,
+            'annotations': self.annotations,
+            'path': self.path,
+        }
+        if self.parent_id:
+            d['parent_id'] = self.parent_id
+        if self.parent:
+            d['parent'] = request.resource_url(self.parent, 'json')
+        children = dict([
+            (child.title, request.resource_url(child, 'json'))
+            for child in self.children
+        ])
+        d['children'] = children
+        return d
+
 
 class TypeInfo(object):
     """TypeInfo instances contain information about the type of a node.
@@ -414,6 +435,13 @@ class TypeInfo(object):
 
         return match_score
 
+    def __json__(self, request):
+        return {
+            'name': self.name,
+            'title': self.title,
+            'addable_to': self.addable_to,
+            'add_view': self.add_view,
+        }
 
 class Tag(Base):
     """Basic tag implementation.  Instances of this class are just the tag
@@ -593,6 +621,22 @@ class Content(Node):
         # Same as `Node.copy` with additional tag support.
         kwargs['tags'] = self.tags
         return super(Content, self).copy(**kwargs)
+
+    def __json__(self, request):
+        d = super(Content, self).__json__(request)
+        d.update({
+            'default_view': self.default_view,
+            'description': self.description,
+            'language': self.language,
+            'owner': self.owner,
+            'state': self.state,
+            'creation_date': self.creation_date,
+            'modification_date': self.modification_date,
+            'in_navigation': self.in_navigation,
+            'tags': [tag.encode('utf-8') for tag in self.tags],
+            'type_info': self.type_info,
+        })
+        return d
 
 
 class Document(Content):

--- a/kotti/util.py
+++ b/kotti/util.py
@@ -150,6 +150,12 @@ class LinkRenderer(LinkBase):
     def selected(self, context, request):
         return False
 
+    def __json__(self, request):
+        return {
+            'name': self.name,
+            'predicate': self.predicate,
+        }
+
 
 class LinkParent(LinkBase):
     """A menu link that renders sublinks in a dropdown.
@@ -168,6 +174,12 @@ class LinkParent(LinkBase):
 
     def get_visible_children(self, context, request):
         return [ch for ch in self.children if ch.visible(context, request)]
+
+    def __json__(self, request):
+        return {
+            'title': self.title,
+            'children': self.children,
+        }
 
 
 class Link(LinkBase):
@@ -188,6 +200,12 @@ class Link(LinkBase):
 
     def __repr__(self):
         return "Link(%r, %r)" % (self.name, self.title)
+
+    def __json__(self, request):
+        return {
+            'name': self.name,
+            'title': self.title,
+        }
 
 
 class ActionButton(Link):


### PR DESCRIPTION
This makes it easier to create JSON views that show information about objects by doing something like:

    config.add_view(
        lambda context, request: context,
        context=IContent,
        name='json',
        permission='view',
        renderer='json',
    )

Which allows you to do stuff like:

$ http http://127.0.0.1:5000/facilities/json 'Cookie:...'
HTTP/1.1 200 OK
Cache-Control: max-age=0
Content-Length: 915
Content-Type: application/json; charset=UTF-8
Date: Fri, 23 Jan 2015 23:45:27 GMT
Expires: Thu, 22 Jan 2015 23:45:27 GMT
Server: waitress
X-Caching-Policy: No Cache

{
    "annotations": {},
    "children": {
        "AWS": "http://127.0.0.1:5000/facilities/aws/json",
        "Linode": "http://127.0.0.1:5000/facilities/linode/json",
        "Rackspace": "http://127.0.0.1:5000/facilities/rackspace/json",
    },
    "creation_date": "2015-01-21T06:45:33.329003",
    "default_view": null,
    "description": "This is where we keep track of our facilities",
    "id": 12,
    "in_navigation": true,
    "language": null,
    "modification_date": "2015-01-22T17:54:14.370772",
    "name": "facilities",
    "owner": "admin",
    "parent": "http://127.0.0.1:5000/json",
    "parent_id": 1,
    "path": "/facilities/",
    "position": 1,
    "state": "public",
    "tags": [],
    "title": "Facilities",
    "type": "document",
    "type_info": {
        "add_view": "add_document",
        "addable_to": [
            "Document"
        ],
        "name": "Document",
        "title": "Document"
    }
}