### PR TITLE
README.rst: Add instructions for Docker

### DIFF
--- a/docs/first_steps/installation.rst
+++ b/docs/first_steps/installation.rst
@@ -12,6 +12,18 @@ Requirements
 - ``Xcode`` (on OS X) or
 - equivalent build toolchain for your OS.
 
+Installation using Docker (experimental)
+----------------------------------------
+
+This assumes that you already have Docker_ installed:
+
+.. parsed-literal::
+
+  docker pull kotti/kotti
+  docker run -i -t -p 5000:5000 kotti/kotti
+
+This should get you a running Kotti instance on port 5000.
+
 Installation using ``virtualenv``
 ---------------------------------
 
@@ -63,3 +75,4 @@ Although SQLite may prove to be adequate for some deployments, Kotti is flexible
 .. _other SQL databases: http://www.sqlalchemy.org/docs/core/engines.html#supported-databases
 .. _virtualenv: http://pypi.python.org/pypi/virtualenv
 .. _Paste Deploy: http://pythonpaste.org/deploy/#the-config-file
+.. _Docker: http://docker.io/


### PR DESCRIPTION
These steps worked for me using docker-osx on OS X 10.9.5. 

In theory, they should work anywhere. 