### PR TITLE
README.rst: Add link to installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,13 @@ Its **main features** are:
 .. _Plone: http://plone.org/
 .. _Twitter Bootstrap: http://twitter.github.com/bootstrap/
 
+Install
+=======
+
+See `installation instructions`_.
+
+.. _installation instructions: http://kotti.readthedocs.org/en/latest/first_steps/installation.html
+
 Support and Documentation
 =========================
 


### PR DESCRIPTION
Because a lot of folks will be curious about how it is installed and/or might be eager to try it out.

Preview at https://github.com/msabramo/Kotti/tree/README_add_link_to_installation