### PR TITLE
added target attribute on kotti.util.Link. See #405

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -54,6 +54,8 @@ Change History
 - Change ``height`` property on ``body``'s widget (``RichTextField``) for
   improved usability. See #403.
 
+- Add ``target`` option to ``kotti.util.Link``. See #405.
+
 1.0.0 - 2015-01-20
 ------------------
 

--- a/kotti/templates/edit/el-link.pt
+++ b/kotti/templates/edit/el-link.pt
@@ -1,6 +1,6 @@
 <li class="${link.selected(context, request) and 'active' or None}"
     tal:condition="link.visible(context, request)">
-  <a href="${link.url(context, request)}">
+  <a href="${link.url(context, request)}" target="${link.target}">
     ${link.title}
   </a>
 </li>

--- a/kotti/tests/test_util.py
+++ b/kotti/tests/test_util.py
@@ -160,3 +160,8 @@ class TestLink:
 
         req.url = "http://example.com"
         assert link.selected(root, req)
+
+    def test_link_target(self):
+        from kotti.util import Link
+        assert Link('').target is None
+        assert Link('', target='_blank').target == '_blank'

--- a/kotti/util.py
+++ b/kotti/util.py
@@ -175,12 +175,13 @@ class LinkParent(LinkBase):
 class Link(LinkBase):
     template = 'kotti:templates/edit/el-link.pt'
 
-    def __init__(self, name, title=None, predicate=None):
+    def __init__(self, name, title=None, predicate=None, target=None):
         self.name = name
         if title is None:
             title = name.replace('-', ' ').replace('_', ' ').title()
         self.title = title
         self.predicate = predicate
+        self.target = target
 
     def url(self, context, request):
         return resource_url(context, request) + '@@' + self.name


### PR DESCRIPTION
Implement #405 (add optional target attribute on ``kotti.util.Link``)