### PR TITLE
Speed up Kotti startup

### DIFF
--- a/kotti/populate.py
+++ b/kotti/populate.py
@@ -42,7 +42,7 @@ def populate():
     lrm.locale_name = get_settings()['pyramid.default_locale_name']
     localizer = lrm.localizer
 
-    if DBSession.query(Node).count() == 0:
+    if DBSession.query(Node.id).count() == 0:
         localized_root_attrs = dict(
             [(k, localizer.translate(v)) for k, v in _ROOT_ATTRS.iteritems()])
         root = Document(**localized_root_attrs)


### PR DESCRIPTION
I've noticed this when opening pshell with an sqlite database, by querying for Node with a bigger set of data, it's quite slow. This will speed it up.