### PR TITLE
Add default_actions variable to facilitate modifying the default actions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,11 @@ Change History
 1.1.0-alpha.2 - unreleased
 --------------------------
 
+- Separate the default actions to a ``kotti.resources.default_actions``
+  variable, to allows easier customization of default actions of all
+  content types. This is a ``LinkParent``, you can append new
+  ``kotti.util.Link`` objects to its ``children``.
+
 - Add ``target`` option to ``kotti.util.Link``. See #405.
 
 - Add sanitizers.  See :ref:`sanitizers` and :mod:`kotti.sanitizers` for

--- a/docs/developing/advanced/add-to-edit-interface.rst
+++ b/docs/developing/advanced/add-to-edit-interface.rst
@@ -22,7 +22,7 @@ There's also:
 Adding a new option to the Administration menu
 ----------------------------------------------
 
-Adding a new link as an option in the *Administration* menu, in the **Site Setup** section is easy. In your ``kotti_configure`` function, add:
+Adding a new link as an option in the **Administration** menu, in the *Site Setup* section is easy. In your ``kotti_configure`` function, add:
 
 .. code-block:: python
 
@@ -35,7 +35,7 @@ Adding a new link as an option in the *Administration* menu, in the **Site Setup
 
 Make a new section in the actions menu
 --------------------------------------
-The **Set default view** section looks really nice. To add your own separated section in the *Action* menu and make that available to all content types:
+The *Set default view* section looks really nice. To add your own separated section in the **Action** menu and make that available to all content types:
 
 .. code-block:: python
 

--- a/docs/developing/advanced/add-to-edit-interface.rst
+++ b/docs/developing/advanced/add-to-edit-interface.rst
@@ -1,0 +1,72 @@
+.. _add-to-edit-interface:
+
+Adding links and actions to the edit interface
+==============================================
+
+This document covers how to customize the available links and actions of the edit interface (the extra tabs and menus that appear after you log in).
+
+The basic building block is the link, ``kotti.util.Link``. Instantiate it as:
+
+.. code-block:: python
+
+    link = Link('name', _(u'Title'))
+
+The name refers to a view name available on the context.
+
+There's also:
+
+    * ``kotti.util.LinkParent``, which allows grouping of links
+    * ``kotti.util.LinkRenderer``, which, instead of generating a simple link, allows you to customize how it's rendered (you can insert anything there, even another submenu based on a ``LinkParent``).
+    * ``kotti.util.ActionButton``, very similar to a simple link, but generates a button instead.
+
+Adding a new option to the Administration menu
+----------------------------------------------
+
+Adding a new link as an option in the *Administration* menu, in the **Site Setup** section is easy. In your ``kotti_configure`` function, add:
+
+.. code-block:: python
+
+    from kotti.util import Link
+    from kotti.views.site_setup import CONTROL_PANEL_LINKS
+
+    def kotti_configure(settings):
+        link = Link('name', _(u'Title'))
+        CONTROL_PANEL_LINKS.append(link)
+
+Make a new section in the actions menu
+--------------------------------------
+The **Set default view** section looks really nice. To add your own separated section in the *Action* menu and make that available to all content types:
+
+.. code-block:: python
+
+    from kotti.util import LinkRenderer
+    from kotti.resources import default_actions
+
+    def kotti_configure(settings):
+        default_actions.children.append(LinkRenderer("my-custom-submenu"))
+
+So far we've added a ``LinkRenderer`` to the ``default_actions`` which are used by all content inheriting ``Content``. This LinkRenderer will render a view and insert its result in the menu.
+
+.. code-block:: python
+
+    @view_config(
+        name="my-custom-submenu", permission="edit",
+        renderer="mypackage:templates/edit/my-custom-submenu.pt")
+    def my_custom_submenu(context, request):
+        return {}
+
+And the template:
+
+.. code-block:: html
+
+    <tal:menu i18n:domain="mypackage">
+        <li class="divider"></li>
+        <li role="presentation" class="dropdown-header" i18n:translate="">
+            My own actions
+        </li>
+        <li>
+            <a i18n:translate="" href="${request.resource_url(context, 'someview')}">
+                View title here
+            </a>
+        </li>
+    </tal:menu

--- a/docs/developing/advanced/add-to-edit-interface.rst
+++ b/docs/developing/advanced/add-to-edit-interface.rst
@@ -43,7 +43,7 @@ The **Set default view** section looks really nice. To add your own separated se
     from kotti.resources import default_actions
 
     def kotti_configure(settings):
-        default_actions.children.append(LinkRenderer("my-custom-submenu"))
+        default_actions.append(LinkRenderer("my-custom-submenu"))
 
 So far we've added a ``LinkRenderer`` to the ``default_actions`` which are used by all content inheriting ``Content``. This LinkRenderer will render a view and insert its result in the menu.
 

--- a/docs/developing/advanced/index.rst
+++ b/docs/developing/advanced/index.rst
@@ -9,6 +9,7 @@ Advanced Topics
     as-a-library
     close-to-anonymous
     default-views
+    add-to-edit-interface
     events
     frontpage-different-template
     images

--- a/kotti/resources.py
+++ b/kotti/resources.py
@@ -495,6 +495,16 @@ def _not_root(context, request):
     return not context is get_root()
 
 
+default_actions = LinkParent(title=_(u'Actions'), children=[
+    Link('copy', title=_(u'Copy')),
+    Link('cut', title=_(u'Cut'), predicate=_not_root),
+    Link('paste', title=_(u'Paste'), predicate=get_paste_items),
+    Link('rename', title=_(u'Rename'), predicate=_not_root),
+    Link('delete', title=_(u'Delete'), predicate=_not_root),
+    LinkRenderer('default-view-selector'),
+])
+
+
 default_type_info = TypeInfo(
     name=u'Content',
     title=u'type_info title missing',   # BBB
@@ -504,14 +514,7 @@ default_type_info = TypeInfo(
         Link('contents', title=_(u'Contents')),
         Link('edit', title=_(u'Edit')),
         Link('share', title=_(u'Share')),
-        LinkParent(title=_(u'Actions'), children=[
-            Link('copy', title=_(u'Copy')),
-            Link('cut', title=_(u'Cut'), predicate=_not_root),
-            Link('paste', title=_(u'Paste'), predicate=get_paste_items),
-            Link('rename', title=_(u'Rename'), predicate=_not_root),
-            Link('delete', title=_(u'Delete'), predicate=_not_root),
-            LinkRenderer('default-view-selector'),
-            ]),
+        default_actions,
         ],
     selectable_default_views=[
         ("folder_view", _(u"Folder view")),

--- a/kotti/resources.py
+++ b/kotti/resources.py
@@ -495,14 +495,14 @@ def _not_root(context, request):
     return not context is get_root()
 
 
-default_actions = LinkParent(title=_(u'Actions'), children=[
+default_actions = [
     Link('copy', title=_(u'Copy')),
     Link('cut', title=_(u'Cut'), predicate=_not_root),
     Link('paste', title=_(u'Paste'), predicate=get_paste_items),
     Link('rename', title=_(u'Rename'), predicate=_not_root),
     Link('delete', title=_(u'Delete'), predicate=_not_root),
     LinkRenderer('default-view-selector'),
-])
+]
 
 
 default_type_info = TypeInfo(
@@ -514,7 +514,7 @@ default_type_info = TypeInfo(
         Link('contents', title=_(u'Contents')),
         Link('edit', title=_(u'Edit')),
         Link('share', title=_(u'Share')),
-        default_actions,
+        LinkParent(title=_(u'Actions'), children=default_actions),
         ],
     selectable_default_views=[
         ("folder_view", _(u"Folder view")),

--- a/kotti/tests/test_util_views.py
+++ b/kotti/tests/test_util_views.py
@@ -175,7 +175,7 @@ class TestTemplateAPI:
         from kotti.resources import default_actions, Document
         from kotti.util import Link
 
-        default_actions.children.append(Link('test', u'Test'))
+        default_actions.append(Link('test', u'Test'))
         assert Document().type_info.edit_links[-1].children[-1].name == 'test'
 
     def test_find_edit_view_not_permitted(self, db_session):

--- a/kotti/tests/test_util_views.py
+++ b/kotti/tests/test_util_views.py
@@ -171,6 +171,13 @@ class TestTemplateAPI:
         api = self.make()
         assert api.edit_links == [open_link]
 
+    def test_default_actions(self):
+        from kotti.resources import default_actions, Document
+        from kotti.util import Link
+
+        default_actions.children.append(Link('test', u'Test'))
+        assert Document().type_info.edit_links[-1].children[-1].name == 'test'
+
     def test_find_edit_view_not_permitted(self, db_session):
         with patch('kotti.views.util.view_permitted', return_value=False):
             api = self.make()


### PR DESCRIPTION
Instead of hunting for that LinkParent, you can now just do default_actions.children.append(Link(...)).