### PR TITLE
Compatibility with alembic >= 0.7.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ Pygments==2.0.2
 SQLAlchemy==0.9.9
 Unidecode==0.04.17
 WebOb==1.4.1
-alembic==0.6.7
+alembic==0.7.6
 appdirs==1.4.0
 bleach==1.4.1
 bleach-whitelist==0.0.7


### PR DESCRIPTION
I've upgraded ``kotti.migrate.stamp_head`` and ``kotti.migrate.upgrade``.

For ``stamp_head`` I've used the "proper api", context.stamp() instead of calling private methods.

For ``upgrade``, the only difference is getting the rev from a tuple. Now alembic supports multiple heads (whatever that means), so it was getting a list of heads instead of a simple revision string.

This probably needs more testing, I've done only a simple test with a dummy migration. It was called properly and the head version was updated.