### PR TITLE
Fix error in kotti-migrate

### DIFF
--- a/kotti/migrate.py
+++ b/kotti/migrate.py
@@ -144,14 +144,15 @@ def upgrade(location=DEFAULT_LOCATION):
     print(u'Upgrading {0}:'.format(pkg_env.location))
 
     def upgrade(heads, context):
-        rev = heads[0]   # alembic supports multiple heads, we don't
+        # alembic supports multiple heads, we don't.
+        # initial revision is () in alembic >= 0.7
+        rev = heads[0] if heads else None
 
         if rev == revision:
             print(u'  - already up to date.')
             return []
 
-        print(u'  - upgrading from {0} to {1}...'.format(
-            rev, revision))
+        print(u'  - upgrading from {0} to {1}...'.format(rev, revision))
 
         return context.script._upgrade_revs(revision, rev)
 
@@ -181,6 +182,7 @@ def list_all():
                 ))
 
         def current_revision(rev, context):
+            rev = rev[0] if rev else None
             print(u"  - current revision: {0}".format(rev))
             return []
         pkg_env.run_env(current_revision)

--- a/kotti/scaffolds/package/+package+/__init__.py_tmpl
+++ b/kotti/scaffolds/package/+package+/__init__.py_tmpl
@@ -24,6 +24,7 @@ def kotti_configure(settings):
     """
 
     settings['pyramid.includes'] += ' {{package}}'
+    settings['kotti.alembic_dirs'] += ' {{package}}:alembic'
     settings['kotti.available_types'] += ' {{package}}.resources.CustomContent'
     settings['kotti.fanstatic.view_needed'] += ' {{package}}.fanstatic.css_and_js'
     File.type_info.addable_to.append('CustomContent')


### PR DESCRIPTION
when running the first migration step for a package (initial revision is ``()`` with alembic >= 0.7).

Also add ``{{package}}:alembic`` to ``kotti.alembic_dirs`` in the scaffold.