### PR TITLE
Compatibility with bowerstatic which shortcuts the pyramid tweens

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,11 @@ Change History
 - Don't try to set a caching header from the NewRequest handler when Pyramid's
   tweens didn't follow the usual chain of calls. This fixes compatibility with
   ``bowerstatic``.
+- Don't assume ``renderer_name`` exists in a rendering event (ex.
+  BeforeRender). The official docstring of ``pyramid.interfaces.IRenderer`` is
+  a bit ambigous in regards to what the ``system`` parameter should include
+  when a renderer gets called. This fixes compatibility with
+  ``pyramid_layout``.
 
 1.1.4 - 2015-06-27
 ------------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Change History
 ------------------
 
 - Fix migration error on MySQL.
+- Don't try to set a caching header from the NewRequest handler when Pyramid's
+  tweens didn't follow the usual chain of calls. This fixes compatibility with
+  ``bowerstatic``.
 
 1.1.4 - 2015-06-27
 ------------------

--- a/kotti/__init__.py
+++ b/kotti/__init__.py
@@ -62,6 +62,7 @@ conf_defaults = {
         'kotti.filedepot',
         'kotti.events',
         'kotti.sanitizers',
+        'kotti.rest',
         'kotti.views',
         'kotti.views.cache',
         'kotti.views.view',

--- a/kotti/__init__.py
+++ b/kotti/__init__.py
@@ -62,7 +62,6 @@ conf_defaults = {
         'kotti.filedepot',
         'kotti.events',
         'kotti.sanitizers',
-        'kotti.rest',
         'kotti.views',
         'kotti.views.cache',
         'kotti.views.view',

--- a/kotti/rest.py
+++ b/kotti/rest.py
@@ -1,4 +1,4 @@
-from kotti.interfaces import IContent, IDocument, IFile, IImage
+from kotti.interfaces import IContent, IDocument, IFile #, IImage
 from pyramid.interfaces import IRequest
 from zope.interface import Interface
 import colander
@@ -30,14 +30,14 @@ def serialize(obj, request, view='add'):
     return serialized
 
 
-def serializes(iface_or_class):
+def serializes(iface_or_class, name=''):
 
     def wrapper(wrapped):
-        def callback(context, name, ob):
+        def callback(context, funcname, ob):
             config = context.config.with_package(info.module)
             config.registry.registerAdapter(
                 wrapped, required=[iface_or_class, IRequest],
-                provided=ISerializer
+                provided=ISerializer, name=name
             )
 
         info = venusian.attach(wrapped, callback, category='pyramid')

--- a/kotti/rest.py
+++ b/kotti/rest.py
@@ -1,3 +1,6 @@
+""" JSON Encoders, serializers, REST views and utilities
+"""
+
 from kotti.resources import Document
 from pyramid.renderers import JSONP
 from pyramid.view import view_config, view_defaults
@@ -59,6 +62,13 @@ class RestView(object):
 datetime_types = (datetime.time, datetime.date, datetime.datetime)
 
 def _encoder(basedefault):
+    """ A JSONEncoder that can encode some basic odd objects.
+
+    For most objects it will execute the basedefault function, which uses
+    adapter lookup mechanism to achieve the encoding, but for some basic
+    objects, such as datetime and colander.null we solve it here.
+    """
+
     class Encoder(json.JSONEncoder):
 
         def default(self, obj):
@@ -83,6 +93,7 @@ def to_json(obj, default=None, **kw):
 
 jsonp = JSONP(param_name='callback', serializer=to_json)
 jsonp.add_adapter(Document, document_serializer)
+
 
 def includeme(config):
 

--- a/kotti/rest.py
+++ b/kotti/rest.py
@@ -1,25 +1,77 @@
 """ JSON Encoders, serializers, REST views and utilities
 """
 
-from kotti.resources import Document
+from kotti.interfaces import IContent, IDocument, IFile #, IImage
+from pyramid.interfaces import IRequest
 from pyramid.renderers import JSONP
 from pyramid.view import view_config, view_defaults
+from zope.interface import Interface
 import colander
 import datetime
 import decimal
 import json
+import venusian
 
 
+class ISerializer(Interface):
+    """ A serializer to change objects to colander cstructs
+    """
+
+    def __call__(request):
+        """ Returns a colander cstruct for context object """
+
+
+def serialize(obj, request, name='view'):
+    """ Serialize an object with the most appropriate serializer
+    """
+
+    reg = request.registry
+
+    serialized = reg.queryMultiAdapter((obj, request), ISerializer, name=name)
+    if serialized is None:
+        serialized = reg.queryMultiAdapter((obj, request), ISerializer)
+
+    if not 'id' in serialized:  # colander schemas don't usually expose 'name'
+        serialized['id'] = obj.__name__
+
+    return serialized
+
+
+def serializes(iface_or_class, name=''):
+    """ A decorator to be used to mark a function as a serializer.
+
+    The decorated function should return a basic python structure usable (along
+    the lines of colander's cstruct) by a JSON encoder.
+    """
+
+    def wrapper(wrapped):
+        def callback(context, funcname, ob):
+            config = context.config.with_package(info.module)
+            config.registry.registerAdapter(
+                wrapped, required=[iface_or_class, IRequest],
+                provided=ISerializer, name=name
+            )
+
+        info = venusian.attach(wrapped, callback, category='pyramid')
+
+        return wrapped
+
+    return wrapper
+
+
+@serializes(IContent)
 def content_serializer(context, request):
     from kotti.views.edit.content import ContentSchema
     return ContentSchema().serialize(context.__dict__)
 
 
+@serializes(IDocument)
 def document_serializer(context, request):
     from kotti.views.edit.content import DocumentSchema
     return DocumentSchema().serialize(context.__dict__)
 
 
+@serializes(IFile)
 def file_serializer(context, request):
     from kotti.views.edit.content import FileSchema
     return FileSchema(None).serialize(context.__dict__)
@@ -92,7 +144,7 @@ def to_json(obj, default=None, **kw):
 
 
 jsonp = JSONP(param_name='callback', serializer=to_json)
-jsonp.add_adapter(Document, document_serializer)
+jsonp.add_adapter(IContent, serialize)
 
 
 def includeme(config):

--- a/kotti/rest.py
+++ b/kotti/rest.py
@@ -1,0 +1,84 @@
+from kotti.interfaces import IContent, IDocument, IFile, IImage
+from pyramid.interfaces import IRequest
+from zope.interface import Interface
+import colander
+import datetime
+import decimal
+import json
+
+
+class ISchemaFactory(Interface):
+    """ Schema factory
+    """
+
+    def __call__(request):
+        """ Returns a colander schema for context object """
+
+
+def serialize(obj, request, view='add', schema=None):
+    """ Use an object's schema to serialize to a colander cstruct """
+    reg = request.registry
+
+    if schema is None:
+        schema = reg.queryMultiAdapter((obj, request), ISchemaFactory, name=view)
+        if schema is None:
+            schema = reg.queryMultiAdapter((obj, request), ISchemaFactory)
+
+
+    serialized = schema.serialize(obj.__dict__)
+    if not 'id' in serialized:  # colander schemas don't usually expose 'name'
+        serialized['id'] = obj.__name__
+
+    return serialized
+
+
+def content_schema(request, context):
+    from kotti.views.edit.content import ContentSchema
+    return ContentSchema()
+
+
+def document_schema(request, context):
+    from kotti.views.edit.content import DocumentSchema
+    return DocumentSchema()
+
+
+def file_schema(request, context):
+    from kotti.views.edit.content import FileSchema
+    # TODO: implement a Base64 file store
+    return FileSchema(None)
+
+
+default_content_schemas = {
+    IContent: content_schema,
+    IDocument: document_schema,
+    IFile: file_schema,
+    IImage: file_schema,
+}
+
+
+datetime_types = (datetime.time, datetime.date, datetime.datetime)
+
+class JSONEncoder(json.JSONEncoder):
+
+    def default(self, obj):
+        """Convert ``obj`` to something JSON encoder can handle."""
+        # if isinstance(obj, NamedTuple):
+        #     obj = dict((k, getattr(obj, k)) for k in obj.keys())
+        if isinstance(obj, decimal.Decimal):
+            obj = str(obj)
+        elif isinstance(obj, datetime_types):
+            obj = str(obj)
+        elif obj is colander.null:
+            obj = None
+        return obj
+
+
+def to_json(obj):
+    return json.dumps(obj, cls=JSONEncoder)
+
+
+def includeme(config):
+    for klass, factory in default_content_schemas.items():
+        config.registry.registerAdapter(factory, required=[klass, IRequest],
+            provided=ISchemaFactory)
+

--- a/kotti/rest.py
+++ b/kotti/rest.py
@@ -70,7 +70,7 @@ def file_serializer(context, request):
 
 ACCEPT = 'application/vnd.api+json'
 
-@view_defaults(name='json', accept=ACCEPT)
+@view_defaults(name='json', accept=ACCEPT, renderer="jsonp")
 class RestView(object):
 
     def __init__(self, context, request):
@@ -80,7 +80,8 @@ class RestView(object):
 
     @view_config(request_method='GET')
     def get(self):
-        return Response(to_json(serialize(self.context, self.request)))
+        return serialize(self.context, self.request)
+        #return Response(to_json(serialize(self.context, self.request)))
 
     @view_config(request_method='POST')
     def post(self):
@@ -120,8 +121,9 @@ def to_json(obj):
     return json.dumps(obj, cls=JSONEncoder)
 
 
-# def includeme(config):
-#     for klass, factory in default_serializers.items():
-#         config.registry.registerAdapter(factory, required=[klass, IRequest],
-#             provided=ISerializer)
-#
+def includeme(config):
+    from pyramid.renderers import JSONP
+
+    config.add_renderer('jsonp', JSONP(param_name='callback'))
+    config.scan(__name__)
+

--- a/kotti/rest.py
+++ b/kotti/rest.py
@@ -1,5 +1,7 @@
 from kotti.interfaces import IContent, IDocument, IFile #, IImage
 from pyramid.interfaces import IRequest
+from pyramid.response import Response
+from pyramid.view import view_config, view_defaults
 from zope.interface import Interface
 import colander
 import datetime
@@ -64,6 +66,37 @@ def file_serializer(context, request):
     from kotti.views.edit.content import FileSchema
     # TODO: implement a Base64 file store
     return FileSchema(None).serialize(context.__dict__)
+
+
+ACCEPT = 'application/vnd.api+json'
+
+@view_defaults(name='json', accept=ACCEPT)
+class RestView(object):
+
+    def __init__(self, context, request):
+
+        self.context = context
+        self.request = request
+
+    @view_config(request_method='GET')
+    def get(self):
+        return Response(to_json(serialize(self.context, self.request)))
+
+    @view_config(request_method='POST')
+    def post(self):
+        pass
+
+    @view_config(request_method='PATCH')
+    def patch(self):
+        pass
+
+    @view_config(request_method='PUT')
+    def put(self):
+        pass
+
+    @view_config(request_method='DELETE')
+    def delete(self):
+        pass
 
 
 datetime_types = (datetime.time, datetime.date, datetime.datetime)

--- a/kotti/tests/test_cache.py
+++ b/kotti/tests/test_cache.py
@@ -66,3 +66,14 @@ class TestSetCacheHeaders:
                 set_cache_headers(event)
 
         assert chooser.call_count == 0
+
+    def test_request_has_no_context(self):
+        from kotti.views.cache import set_cache_headers
+
+        with patch('kotti.views.cache.caching_policy_chooser') as chooser:
+            event = MagicMock()
+            event.request = {}
+            set_cache_headers(event)
+
+            assert chooser.call_count == 0
+

--- a/kotti/tests/test_cache.py
+++ b/kotti/tests/test_cache.py
@@ -76,4 +76,3 @@ class TestSetCacheHeaders:
             set_cache_headers(event)
 
             assert chooser.call_count == 0
-

--- a/kotti/tests/test_rest.py
+++ b/kotti/tests/test_rest.py
@@ -1,87 +1,118 @@
-from kotti.rest import serializes
 from kotti.testing import DummyRequest
-from mock import patch
-from zope.interface import Interface, implements
-import colander
 
-
-class ISomething(Interface):
-    """ dummy """
-
-class Something(object):
-    implements(ISomething)
-
-
-@serializes(ISomething)
-def sa(context, request):
-    return 'a'
-
-
-@serializes(ISomething, name='b')
-def sb(context, request):
-    return 'b'
-
-
-class TestSerializer:
-
-    def test_serializes_decorator(self, config):
-        from kotti.rest import ISerializer
-        from zope.component import getMultiAdapter
-
-        config.scan('kotti.tests.test_rest')
-        obj, req = Something(), DummyRequest()
-
-        assert getMultiAdapter((obj, req), ISerializer, name='b') == 'b'
-        assert getMultiAdapter((obj, req), ISerializer) == 'a'
-
-
-class TestSerializeDefaultContent:
-    from kotti.resources import Content
-
-    def make_one(self, config, klass=Content, **kw):
-        from kotti.rest import serialize
-
-        config.scan('kotti.rest')
-
-        props = {
-            'name': 'doc-a',
-            'title': u'Doc A',
-            'description': u'desc...'
-        }
-        props.update(**kw)
-        obj = klass(**props)
-        return serialize(obj, DummyRequest())
-
-    def test_serialize_content(self, config):
-        from kotti.resources import Content
-        assert self.make_one(config, klass=Content) == {
-            'id': u'doc-a',
-            'title': u'Doc A',
-            'tags': colander.null,
-            'description': u'desc...',
-        }
-
-    def test_serialize_document(self, config):
-        from kotti.resources import Document
-
-        assert self.make_one(config, Document, body=u'Body text')== {
-            'id': u'doc-a',
-            'title': u'Doc A',
-            'tags': colander.null,
-            'description': u'desc...',
-            'body': u'Body text',
-        }
-
-    def test_serialize_file(self, config, filedepot):
-        from kotti.resources import File
-        res = self.make_one(config, File, data='file content')
-        print res
-
-    # TODO: serializing an image
+# from kotti.rest import serializes
+# from mock import patch
+# from zope.interface import Interface, implements
+# import colander
+#
+#
+# class ISomething(Interface):
+#     """ dummy """
+#
+# class Something(object):
+#     implements(ISomething)
+#
+#
+# @serializes(ISomething)
+# def sa(context, request):
+#     return 'a'
+#
+#
+# @serializes(ISomething, name='b')
+# def sb(context, request):
+#     return 'b'
+#
+#
+# class TestSerializer:
+#
+#     def test_serializes_decorator(self, config):
+#         from kotti.rest import ISerializer
+#         from zope.component import getMultiAdapter
+#
+#         config.scan('kotti.tests.test_rest')
+#         obj, req = Something(), DummyRequest()
+#
+#         assert getMultiAdapter((obj, req), ISerializer, name='b') == 'b'
+#         assert getMultiAdapter((obj, req), ISerializer) == 'a'
+#
+#
+# class TestSerializeDefaultContent:
+#     from kotti.resources import Content
+#
+#     def make_one(self, config, klass=Content, **kw):
+#         from kotti.rest import serialize
+#
+#         config.scan('kotti.rest')
+#
+#         props = {
+#             'name': 'doc-a',
+#             'title': u'Doc A',
+#             'description': u'desc...'
+#         }
+#         props.update(**kw)
+#         obj = klass(**props)
+#         return serialize(obj, DummyRequest())
+#
+#     def test_serialize_content(self, config):
+#         from kotti.resources import Content
+#         assert self.make_one(config, klass=Content) == {
+#             'id': u'doc-a',
+#             'title': u'Doc A',
+#             'tags': colander.null,
+#             'description': u'desc...',
+#         }
+#
+#     def test_serialize_document(self, config):
+#         from kotti.resources import Document
+#
+#         assert self.make_one(config, Document, body=u'Body text')== {
+#             'id': u'doc-a',
+#             'title': u'Doc A',
+#             'tags': colander.null,
+#             'description': u'desc...',
+#             'body': u'Body text',
+#         }
+#
+#     def test_serialize_file(self, config, filedepot):
+#         from kotti.resources import File
+#         res = self.make_one(config, File, data='file content')
+#         print res
+#
+#     # TODO: serializing an image
+#
+#
+# class TestRestView:
+#     def get_view(self, context, request, name):
+#         from pyramid.compat import map_
+#         from pyramid.interfaces import IView
+#         from pyramid.interfaces import IViewClassifier
+#         from zope.interface import providedBy
+#
+#         provides = [IViewClassifier] + map_(
+#             providedBy,
+#             (request, context)
+#         )
+#
+#         return request.registry.adapters.lookup(provides, IView, name=name)
+#
+#     def test_predicate_matching(self, config):
+#         from kotti.resources import Document
+#         from kotti.rest import ACCEPT
+#         from webob.acceptparse import MIMEAccept
+#         config.include('kotti.rest')
+#
+#         req = DummyRequest(accept=MIMEAccept(ACCEPT))
+#         doc = Document()
+#
+#         with patch('kotti.rest.serialize') as serialize:
+#             serialize.return_value = 'a'
+#             view = self.get_view(doc, req, name='json')
+#             resp = view(doc, req)
+#             assert resp.json == u'a'
 
 
 class TestRestView:
-    def get_view(self, context, request, name):
+    def get_view(self, context, request, name='json'):
         from pyramid.compat import map_
         from pyramid.interfaces import IView
         from pyramid.interfaces import IViewClassifier
@@ -98,13 +129,12 @@ class TestRestView:
         from kotti.resources import Document
         from kotti.rest import ACCEPT
         from webob.acceptparse import MIMEAccept
+
         config.include('kotti.rest')
 
         req = DummyRequest(accept=MIMEAccept(ACCEPT))
         doc = Document()
 
-        with patch('kotti.rest.serialize') as serialize:
-            serialize.return_value = 'a'
-            view = self.get_view(doc, req, name='json')
-            resp = view(doc, req)
-            assert resp.json == u'a'
+        view = self.get_view(doc, req, name='json')
+        resp = view(doc, req)
+        import pdb; pdb.set_trace()

--- a/kotti/tests/test_rest.py
+++ b/kotti/tests/test_rest.py
@@ -137,4 +137,4 @@ class TestRestView:
 
         view = self.get_view(doc, req, name='json')
         resp = view(doc, req)
-        import pdb; pdb.set_trace()
+        assert resp.json

--- a/kotti/tests/test_rest.py
+++ b/kotti/tests/test_rest.py
@@ -1,23 +1,22 @@
+from kotti.resources import TypeInfo, Content
 from kotti.rest import serializes
 from kotti.testing import DummyRequest
-from zope.interface import Interface, implements
+from sqlalchemy import Column, ForeignKey, Integer
 import colander
 import json
 
 
-class ISomething(Interface):
-    """ dummy """
-
-class Something(object):
-    implements(ISomething)
+class Something(Content):
+    id = Column(Integer(), ForeignKey('contents.id'), primary_key=True)
+    type_info = TypeInfo(name="Something")
 
 
-@serializes(ISomething)
+@serializes(Something)
 def sa(context, request):
     return 'a'
 
 
-@serializes(ISomething, name='b')
+@serializes(Something, name='b')
 def sb(context, request):
     return 'b'
 
@@ -32,7 +31,7 @@ class TestSerializer:
         obj, req = Something(), DummyRequest()
 
         assert getMultiAdapter((obj, req), ISerializer, name='b') == 'b'
-        assert getMultiAdapter((obj, req), ISerializer) == 'a'
+        assert getMultiAdapter((obj, req), ISerializer, name='Something') == 'a'
 
 
 class TestSerializeDefaultContent:
@@ -64,7 +63,7 @@ class TestSerializeDefaultContent:
     def test_serialize_document(self, config):
         from kotti.resources import Document
 
-        assert self.make_one(config, Document, body=u'Body text')== {
+        assert self.make_one(config, Document, body=u'Body text') == {
             'id': u'doc-a',
             'title': u'Doc A',
             'tags': colander.null,
@@ -124,4 +123,3 @@ class TestRestViewA:
             "description": "",
             "title": ""
         }
-

--- a/kotti/tests/test_rest.py
+++ b/kotti/tests/test_rest.py
@@ -2,6 +2,7 @@ from kotti.rest import serializes
 from kotti.testing import DummyRequest
 from zope.interface import Interface, implements
 import colander
+import json
 
 
 class ISomething(Interface):
@@ -110,29 +111,17 @@ class TestRestViewA:
     def test_jsonp_as_renderer(self, config):
         from pyramid.renderers import render
         from kotti.resources import Document
-        from pyramid.threadlocal import manager
 
         config.include('kotti.rest')
 
         doc = Document('1')
         req = DummyRequest()
 
-        manager.push({'registry': config.registry, 'request': req})
+        assert json.loads(render('kotti_jsonp', doc, request=req)) == {
+            "body": "1",
+            "tags": None,
+            "id": None,
+            "description": "",
+            "title": ""
+        }
 
-        assert render('kotti_jsonp', doc) == '{"body": "1", "tags": null, '\
-            '"description": "", "title": ""}'
-
-    def test_jsonp_as_serializer(self, config):
-        from kotti.rest import jsonp
-        from kotti.resources import Document
-
-        config.include('kotti.rest')
-        default = jsonp._make_default(DummyRequest())
-
-        doc = Document('1')
-        serialized = default(doc)
-
-        assert serialized == {'body': u'1',
-                              'tags': colander.null,
-                              'description': u'',
-                              'title': u''}

--- a/kotti/tests/test_rest.py
+++ b/kotti/tests/test_rest.py
@@ -8,7 +8,7 @@ class TestSerializer:
     def make_one(self, config, klass=Content, **kw):
         from kotti.rest import serialize
 
-        config.include('kotti.rest')
+        config.scan('kotti.rest')
 
         props = {
             'name': 'doc-a',
@@ -42,5 +42,6 @@ class TestSerializer:
     def test_serialize_file(self, config, filedepot):
         from kotti.resources import File
         res = self.make_one(config, File, data='file content')
+        print res
 
     # serializing an image

--- a/kotti/tests/test_rest.py
+++ b/kotti/tests/test_rest.py
@@ -1,0 +1,46 @@
+import colander
+from kotti.testing import DummyRequest
+
+
+class TestSerializer:
+    from kotti.resources import Content
+
+    def make_one(self, config, klass=Content, **kw):
+        from kotti.rest import serialize
+
+        config.include('kotti.rest')
+
+        props = {
+            'name': 'doc-a',
+            'title': u'Doc A',
+            'description': u'desc...'
+        }
+        props.update(**kw)
+        obj = klass(**props)
+        return serialize(obj, DummyRequest())
+
+    def test_serialize_content(self, config):
+        from kotti.resources import Content
+        assert self.make_one(config, klass=Content) == {
+            'id': u'doc-a',
+            'title': u'Doc A',
+            'tags': colander.null,
+            'description': u'desc...',
+        }
+
+    def test_serialize_document(self, config):
+        from kotti.resources import Document
+
+        assert self.make_one(config, Document, body=u'Body text')== {
+            'id': u'doc-a',
+            'title': u'Doc A',
+            'tags': colander.null,
+            'description': u'desc...',
+            'body': u'Body text',
+        }
+
+    def test_serialize_file(self, config, filedepot):
+        from kotti.resources import File
+        res = self.make_one(config, File, data='file content')
+
+    # serializing an image

--- a/kotti/tests/test_rest.py
+++ b/kotti/tests/test_rest.py
@@ -1,8 +1,40 @@
 import colander
 from kotti.testing import DummyRequest
+from kotti.rest import serializes
+from zope.interface import Interface, implements
+
+
+class ISomething(Interface):
+    """ dummy """
+
+class Something(object):
+    implements(ISomething)
+
+
+@serializes(ISomething)
+def sa(context, request):
+    return 'a'
+
+
+@serializes(ISomething, name='b')
+def sb(context, request):
+    return 'b'
 
 
 class TestSerializer:
+
+    def test_serializes_decorator(self, config):
+        from kotti.rest import ISerializer
+        from zope.component import getMultiAdapter
+
+        config.scan('kotti.tests.test_rest')
+        obj, req = Something(), DummyRequest()
+
+        assert getMultiAdapter((obj, req), ISerializer, name='b') == 'b'
+        assert getMultiAdapter((obj, req), ISerializer) == 'a'
+
+
+class TestSerializeDefaultContent:
     from kotti.resources import Content
 
     def make_one(self, config, klass=Content, **kw):

--- a/kotti/tests/test_rest.py
+++ b/kotti/tests/test_rest.py
@@ -138,3 +138,29 @@ class TestRestView:
         view = self.get_view(doc, req, name='json')
         resp = view(doc, req)
         assert resp.json
+
+    def test_jsonp_as_renderer(self, config):
+        from pyramid.renderers import render
+        from kotti.resources import Document
+
+        doc = Document('1')
+        config.include('kotti.rest')
+
+        assert render('kotti_jsonp', doc) == '{"body": "1", "tags": null, '\
+            '"description": "", "title": ""}'
+
+    def test_jsonp_as_serializer(self, config):
+        from kotti.rest import jsonp
+        from kotti.resources import Document
+        import colander
+
+        config.include('kotti.rest')
+        default = jsonp._make_default(DummyRequest())
+
+        doc = Document('1')
+        serialized = default(doc)
+
+        assert serialized == {'body': u'1',
+                              'tags': colander.null,
+                              'description': u'',
+                              'title': u''}

--- a/kotti/tests/test_rest.py
+++ b/kotti/tests/test_rest.py
@@ -98,7 +98,7 @@ class TestRestView:
         from kotti.resources import Document
         from kotti.rest import ACCEPT
         from webob.acceptparse import MIMEAccept
-        config.scan('kotti.rest')
+        config.include('kotti.rest')
 
         req = DummyRequest(accept=MIMEAccept(ACCEPT))
         doc = Document()

--- a/kotti/tests/test_rest.py
+++ b/kotti/tests/test_rest.py
@@ -1,118 +1,86 @@
+from kotti.rest import serializes
 from kotti.testing import DummyRequest
-
-# from kotti.rest import serializes
-# from mock import patch
-# from zope.interface import Interface, implements
-# import colander
-#
-#
-# class ISomething(Interface):
-#     """ dummy """
-#
-# class Something(object):
-#     implements(ISomething)
-#
-#
-# @serializes(ISomething)
-# def sa(context, request):
-#     return 'a'
-#
-#
-# @serializes(ISomething, name='b')
-# def sb(context, request):
-#     return 'b'
-#
-#
-# class TestSerializer:
-#
-#     def test_serializes_decorator(self, config):
-#         from kotti.rest import ISerializer
-#         from zope.component import getMultiAdapter
-#
-#         config.scan('kotti.tests.test_rest')
-#         obj, req = Something(), DummyRequest()
-#
-#         assert getMultiAdapter((obj, req), ISerializer, name='b') == 'b'
-#         assert getMultiAdapter((obj, req), ISerializer) == 'a'
-#
-#
-# class TestSerializeDefaultContent:
-#     from kotti.resources import Content
-#
-#     def make_one(self, config, klass=Content, **kw):
-#         from kotti.rest import serialize
-#
-#         config.scan('kotti.rest')
-#
-#         props = {
-#             'name': 'doc-a',
-#             'title': u'Doc A',
-#             'description': u'desc...'
-#         }
-#         props.update(**kw)
-#         obj = klass(**props)
-#         return serialize(obj, DummyRequest())
-#
-#     def test_serialize_content(self, config):
-#         from kotti.resources import Content
-#         assert self.make_one(config, klass=Content) == {
-#             'id': u'doc-a',
-#             'title': u'Doc A',
-#             'tags': colander.null,
-#             'description': u'desc...',
-#         }
-#
-#     def test_serialize_document(self, config):
-#         from kotti.resources import Document
-#
-#         assert self.make_one(config, Document, body=u'Body text')== {
-#             'id': u'doc-a',
-#             'title': u'Doc A',
-#             'tags': colander.null,
-#             'description': u'desc...',
-#             'body': u'Body text',
-#         }
-#
-#     def test_serialize_file(self, config, filedepot):
-#         from kotti.resources import File
-#         res = self.make_one(config, File, data='file content')
-#         print res
-#
-#     # TODO: serializing an image
-#
-#
-# class TestRestView:
-#     def get_view(self, context, request, name):
-#         from pyramid.compat import map_
-#         from pyramid.interfaces import IView
-#         from pyramid.interfaces import IViewClassifier
-#         from zope.interface import providedBy
-#
-#         provides = [IViewClassifier] + map_(
-#             providedBy,
-#             (request, context)
-#         )
-#
-#         return request.registry.adapters.lookup(provides, IView, name=name)
-#
-#     def test_predicate_matching(self, config):
-#         from kotti.resources import Document
-#         from kotti.rest import ACCEPT
-#         from webob.acceptparse import MIMEAccept
-#         config.include('kotti.rest')
-#
-#         req = DummyRequest(accept=MIMEAccept(ACCEPT))
-#         doc = Document()
-#
-#         with patch('kotti.rest.serialize') as serialize:
-#             serialize.return_value = 'a'
-#             view = self.get_view(doc, req, name='json')
-#             resp = view(doc, req)
-#             assert resp.json == u'a'
+from zope.interface import Interface, implements
+import colander
 
 
-class TestRestView:
-    def get_view(self, context, request, name='json'):
+class ISomething(Interface):
+    """ dummy """
+
+class Something(object):
+    implements(ISomething)
+
+
+@serializes(ISomething)
+def sa(context, request):
+    return 'a'
+
+
+@serializes(ISomething, name='b')
+def sb(context, request):
+    return 'b'
+
+
+class TestSerializer:
+
+    def test_serializes_decorator(self, config):
+        from kotti.rest import ISerializer
+        from zope.component import getMultiAdapter
+
+        config.scan('kotti.tests.test_rest')
+        obj, req = Something(), DummyRequest()
+
+        assert getMultiAdapter((obj, req), ISerializer, name='b') == 'b'
+        assert getMultiAdapter((obj, req), ISerializer) == 'a'
+
+
+class TestSerializeDefaultContent:
+    from kotti.resources import Content
+
+    def make_one(self, config, klass=Content, **kw):
+        from kotti.rest import serialize
+
+        config.scan('kotti.rest')
+
+        props = {
+            'name': 'doc-a',
+            'title': u'Doc A',
+            'description': u'desc...'
+        }
+        props.update(**kw)
+        obj = klass(**props)
+        return serialize(obj, DummyRequest())
+
+    def test_serialize_content(self, config):
+        from kotti.resources import Content
+        assert self.make_one(config, klass=Content) == {
+            'id': u'doc-a',
+            'title': u'Doc A',
+            'tags': colander.null,
+            'description': u'desc...',
+        }
+
+    def test_serialize_document(self, config):
+        from kotti.resources import Document
+
+        assert self.make_one(config, Document, body=u'Body text')== {
+            'id': u'doc-a',
+            'title': u'Doc A',
+            'tags': colander.null,
+            'description': u'desc...',
+            'body': u'Body text',
+        }
+
+    def test_serialize_file(self, config, filedepot):
+        from kotti.resources import File
+        res = self.make_one(config, File, data='file content')
+        assert res  # TODO: finish
+
+    # TODO: serializing an image
+
+
+class TestRestViewA:
+    def get_view(self, context, request, name):
         from pyramid.compat import map_
         from pyramid.interfaces import IView
         from pyramid.interfaces import IViewClassifier
@@ -142,9 +110,14 @@ class TestRestView:
     def test_jsonp_as_renderer(self, config):
         from pyramid.renderers import render
         from kotti.resources import Document
+        from pyramid.threadlocal import manager
+
+        config.include('kotti.rest')
 
         doc = Document('1')
-        config.include('kotti.rest')
+        req = DummyRequest()
+
+        manager.push({'registry': config.registry, 'request': req})
 
         assert render('kotti_jsonp', doc) == '{"body": "1", "tags": null, '\
             '"description": "", "title": ""}'
@@ -152,7 +125,6 @@ class TestRestView:
     def test_jsonp_as_serializer(self, config):
         from kotti.rest import jsonp
         from kotti.resources import Document
-        import colander
 
         config.include('kotti.rest')
         default = jsonp._make_default(DummyRequest())

--- a/kotti/tests/test_util_views.py
+++ b/kotti/tests/test_util_views.py
@@ -522,6 +522,17 @@ class TestViewUtil:
         add_renderer_globals(event)
         assert 'api' in event
 
+    def test_add_renderer_globals_event_has_no_renderer_name(self, db_session):
+        from kotti.views.util import add_renderer_globals
+
+        request = DummyRequest()
+        event = {
+            'request': request,
+            'context': object(),
+            }
+        add_renderer_globals(event)
+        assert 'api' in event
+
 
 class TestLocalNavigationSlot:
     def test_it(self, config, root):

--- a/kotti/views/cache.py
+++ b/kotti/views/cache.py
@@ -103,6 +103,12 @@ def caching_policy_chooser(context, request, response):
 @subscriber(NewResponse)
 def set_cache_headers(event):
     request, response = event.request, event.response
+
+    # this can happen if a Pyramid tween will shortcut the normal tween
+    # chain processing and return its own response early
+    if not hasattr(event.request, 'context'):
+        return
+
     context = event.request.context
 
     # If no caching policy was previously set (by setting the

--- a/kotti/views/util.py
+++ b/kotti/views/util.py
@@ -72,7 +72,7 @@ def template_api(context, request, **kwargs):
 
 
 def add_renderer_globals(event):
-    if event['renderer_name'] != 'json':
+    if event.get('renderer_name') != 'json':
         request = event['request']
         api = getattr(request, 'template_api', None)
         if api is None and request is not None:


### PR DESCRIPTION
This is the problem that this fixes::

<pre>
Traceback (most recent call last):
  File "/home/cruxlog/lib/python2.7/site-packages/waitress/channel.py", line 337, in service
    task.service()
  File "/home/cruxlog/lib/python2.7/site-packages/waitress/task.py", line 173, in service
    self.execute()
  File "/home/cruxlog/lib/python2.7/site-packages/waitress/task.py", line 392, in execute
    app_iter = self.channel.server.application(env, start_response)
  File "/home/cruxlog/lib/python2.7/site-packages/pyramid/router.py", line 242, in __call__
    response = self.invoke_subrequest(request, use_tweens=True)
  File "/home/cruxlog/lib/python2.7/site-packages/pyramid/router.py", line 222, in invoke_subrequest
    has_listeners and notify(NewResponse(request, response))
  File "/home/cruxlog/lib/python2.7/site-packages/pyramid/registry.py", line 74, in notify
    [ _ for _ in self.subscribers(events, None) ]
  File "/home/cruxlog/lib/python2.7/site-packages/zope/interface/registry.py", line 328, in subscribers
    return self.adapters.subscribers(objects, provided)
  File "/home/cruxlog/lib/python2.7/site-packages/zope/interface/adapter.py", line 600, in subscribers
    subscription(*objects)
  File "/home/cruxlog/lib/python2.7/site-packages/pyramid/config/adapters.py", line 103, in derived_subscriber
    return subscriber(arg[0])
  File "/home/cruxlog/src/kotti/kotti/views/cache.py", line 106, in set_cache_headers
    
AttributeError: 'Request' object has no attribute 'context'
</pre>

The pyramid Router.handle_request has not been called by the chain of tweens and as a result the request has no context.