### PR TITLE
WIP: Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - KOTTI_TEST_DB_STRING=sqlite://
 install:
   - travis_retry pip install "pip==1.3.1"  # fix issue with fanstatic==1.0a
+  - travis_retry pip install "setuptools>=17.1"  # fix issue with mock==1.3.0
   - travis_retry pip install -e . -r requirements.txt --use-mirrors
   - pip uninstall -y Kotti
   - python setup.py develop

--- a/kotti/resources.py
+++ b/kotti/resources.py
@@ -809,7 +809,7 @@ def get_root(request=None):
 
 
 class DefaultRootCache(object):
-    """docstring for DefaultGetRoot"""
+    """ Default implementation for :func:`~kotti.resources.get_root` """
 
     @reify
     def root_id(self):
@@ -831,26 +831,22 @@ class DefaultRootCache(object):
 
         return Node.query.get(self.root_id)
 
+    def __call__(self, request=None):
+        """ Default implementation for :func:`~kotti.resources.get_root`
 
-def default_get_root(request=None):
-    """Default implementation for :func:`~kotti.resources.get_root`.
+        :param request: Current request (optional)
+        :type request: :class:`kotti.request.Request`
 
-    :param request: Current request (optional)
-    :type request: :class:`kotti.request.Request`
+        :result: Node in the object tree that has no parent.
+        :rtype: :class:`~kotti.resources.Node` or descendant;
+                in a fresh Kotti site with Kotti's
+                :func:`default populator <kotti.populate.populate>` this will
+                be an instance of :class:`~kotti.resources.Document`.
+        """
 
-    :result: Node in the object tree that has no parent.
-    :rtype: :class:`~kotti.resources.Node` or descendant; in a fresh Kotti site
-            with Kotti's :func:`default populator <kotti.populate.populate>`
-            this will be an instance of :class:`~kotti.resources.Document`.
-    """
+        return self.get_root()
 
-    # Get the root cache, make one if it doesn't exist yet.
-    try:
-        drc = get_settings()['kotti.default_root_cache']
-    except KeyError:
-        drc = get_settings()['kotti.default_root_cache'] = DefaultRootCache()
-
-    return drc.get_root()
+default_get_root = DefaultRootCache()
 
 
 def _adjust_for_engine(engine):

--- a/kotti/resources.py
+++ b/kotti/resources.py
@@ -274,6 +274,7 @@ class Node(Base, ContainerMixin, PersistentACLMixin):
         LocalGroup,
         backref=backref('node'),
         cascade='all',
+        lazy='joined',
         )
 
     def __init__(self, name=None, parent=None, title=u"", annotations=None,

--- a/kotti/resources.py
+++ b/kotti/resources.py
@@ -18,6 +18,7 @@ from UserDict import DictMixin
 from depot.fields.sqlalchemy import _SQLAMutationTracker
 from depot.fields.sqlalchemy import UploadedFileField
 from kotti import _resolve_dotted
+from pyramid.decorator import reify
 from pyramid.traversal import resource_path
 from sqlalchemy import Boolean
 from sqlalchemy import Column
@@ -111,10 +112,27 @@ class ContainerMixin(object, DictMixin):
             else:
                 return child
 
+        # Get a single child by its name
         if len(path) == 1:
+            # Add a cache dict if it doesn't exist yet
+            if '_child_cache' not in self.__dict__:
+                self._child_cache = {}
+            if path[0] in self._child_cache:
+                child = self._child_cache[path[0]]
+                # Only return an item from the cache if it's still a child
+                # (i.e. it hasn't been assigned to a different parent in the
+                # meantime).
+                if child.parent == self:
+                    return child
+                else:
+                    # remove item from the cache if the parent has changed.
+                    self._child_cache.pop(path[0])
             try:
-                return DBSession.query(Node).filter_by(
+                child = DBSession.query(Node).filter_by(
                     name=path[0], parent=self).one()
+                # put the item in the cache for subsequent access
+                self._child_cache[path[0]] = child
+                return child
             except NoResultFound:
                 raise KeyError(path)
 
@@ -789,6 +807,30 @@ def get_root(request=None):
     return get_settings()['kotti.root_factory'][0](request)
 
 
+class DefaultRootCache(object):
+    """docstring for DefaultGetRoot"""
+
+    @reify
+    def root_id(self):
+        """ Query for the one node without a parent and return its id.
+
+        :result: The root node's id.
+        :rtype: int
+        """
+
+        return Node.query.filter(Node.parent_id == None).one().id  # noqa
+
+    def get_root(self):
+        """ Query for the root node by its id.  This enables SQLAlchemy's
+        session cache (query is executed only once per session).
+
+        :result: The root node.
+        :rtype: :class:`Node`.
+        """
+
+        return Node.query.get(self.root_id)
+
+
 def default_get_root(request=None):
     """Default implementation for :func:`~kotti.resources.get_root`.
 
@@ -801,7 +843,13 @@ def default_get_root(request=None):
             this will be an instance of :class:`~kotti.resources.Document`.
     """
 
-    return DBSession.query(Node).filter(Node.parent_id == None).one()  # noqa
+    # Get the root cache, make one if it doesn't exist yet.
+    try:
+        drc = get_settings()['kotti.default_root_cache']
+    except KeyError:
+        drc = get_settings()['kotti.default_root_cache'] = DefaultRootCache()
+
+    return drc.get_root()
 
 
 def _adjust_for_engine(engine):

--- a/kotti/security.py
+++ b/kotti/security.py
@@ -269,14 +269,14 @@ def list_groups_raw(name, context):
     Only groups defined in context will be considered, therefore no
     global or inherited groups are returned.
     """
-    from kotti.resources import LocalGroup
+
     from kotti.resources import Node
 
     if isinstance(context, Node):
         return set(
-            r[0] for r in DBSession.query(LocalGroup.group_name).filter(
-                LocalGroup.node_id == context.id).filter(
-                LocalGroup.principal_name == name).all())
+            r.group_name for r in context.local_groups
+            if r.principal_name == name
+        )
     return set()
 
 
@@ -339,14 +339,19 @@ def set_groups(name, context, groups_to_set=()):
     """Set the list of groups for principal with given ``name`` and in
     given ``context``.
     """
-    name = unicode(name)
-    from kotti.resources import LocalGroup
-    DBSession.query(LocalGroup).filter(
-        LocalGroup.node_id == context.id).filter(
-        LocalGroup.principal_name == name).delete()
 
-    for group_name in groups_to_set:
-        DBSession.add(LocalGroup(context, name, unicode(group_name)))
+    from kotti.resources import LocalGroup
+
+    name = unicode(name)
+    context.local_groups = [
+        # keep groups for "other" principals
+        lg for lg in context.local_groups
+        if lg.principal_name != name
+    ] + [
+        # reset groups for given principal
+        LocalGroup(context, name, unicode(group_name))
+        for group_name in groups_to_set
+    ]
 
 
 def list_groups_callback(name, request):
@@ -396,19 +401,19 @@ def principals_with_local_roles(context, inherit=True):
     """Return a list of principal names that have local roles in the
     context.
     """
-    from resources import LocalGroup
+
     principals = set()
     items = [context]
+
     if inherit:
         items = lineage(context)
+
     for item in items:
         principals.update(
-            r[0] for r in
-            DBSession.query(LocalGroup.principal_name).filter(
-                LocalGroup.node_id == item.id).group_by(
-                LocalGroup.principal_name).all()
-            if not r[0].startswith('role:')
-            )
+            r.principal_name for r in item.local_groups
+            if not r.principal_name.startswith('role:')
+        )
+
     return list(principals)
 
 

--- a/kotti/tests/test_upload.py
+++ b/kotti/tests/test_upload.py
@@ -31,8 +31,6 @@ def test_upload_anonymous(root, dummy_request, browser):
     browser.open(u'{0}/content_types'.format(BASE_URL))
     assert browser.url.startswith(u'{0}/@@login'.format(BASE_URL))
 
-    # import pdb; pdb.set_trace()
-
 
 @user('admin')
 def test_upload_authenticated_wo_mimetype(root, dummy_request, browser):

--- a/kotti/tests/test_zzz_scaffolds.py
+++ b/kotti/tests/test_zzz_scaffolds.py
@@ -41,12 +41,17 @@ def virtualenv(request):
     virtualenv.logger = logger
     virtualenv.create_environment(
         virtualenv_directory,
-        site_packages=True,
-        clear=False,
+        site_packages=False,
+        clear=True,
         unzip_setuptools=True)
 
     # chdir into the virtualenv directory
     os.chdir(virtualenv_directory)
+
+    # update setuptools in the virtualenv
+    subprocess.check_call([
+        os.path.join('bin', 'pip'),
+        'install', '-U', 'setuptools>=17.1'])
 
     # install requirements.txt into the virtualenv
     subprocess.check_call([

--- a/kotti/tests/test_zzz_scaffolds.py
+++ b/kotti/tests/test_zzz_scaffolds.py
@@ -51,7 +51,7 @@ def virtualenv(request):
     # update setuptools in the virtualenv
     subprocess.check_call([
         os.path.join('bin', 'pip'),
-        'install', '-U', 'setuptools'])
+        'install', 'setuptools>=17.1'])
 
     # install requirements.txt into the virtualenv
     subprocess.check_call([

--- a/kotti/tests/test_zzz_scaffolds.py
+++ b/kotti/tests/test_zzz_scaffolds.py
@@ -48,11 +48,6 @@ def virtualenv(request):
     # chdir into the virtualenv directory
     os.chdir(virtualenv_directory)
 
-    # update setuptools in the virtualenv
-    subprocess.check_call([
-        os.path.join('bin', 'pip'),
-        'install', 'setuptools>=17.1'])
-
     # install requirements.txt into the virtualenv
     subprocess.check_call([
         os.path.join('bin', 'pip'),

--- a/kotti/tests/test_zzz_scaffolds.py
+++ b/kotti/tests/test_zzz_scaffolds.py
@@ -48,6 +48,11 @@ def virtualenv(request):
     # chdir into the virtualenv directory
     os.chdir(virtualenv_directory)
 
+    # update setuptools in the virtualenv
+    subprocess.check_call([
+        os.path.join('bin', 'pip'),
+        'install', '-U', 'setuptools'])
+
     # install requirements.txt into the virtualenv
     subprocess.check_call([
         os.path.join('bin', 'pip'),


### PR DESCRIPTION
- Add caching for child node access in the tree, as well as for the root node. 
- Use eager / joined loading for local_groups.
- Don't query principals for roles.

These 

  - greatly reduce the number of queries on the DB (typically by 60%, even more for deeply nested content trees) and
  - improve performance (hard to measure in a sensible way, but load times for a specific view in a project we're working on could be reduced by ~ 75%.  Medium page load times on smaller sites should be down by ~25-35%.

@tiberiuichim, @dnouri: please review and comment.