### PR TITLE
Performance (reduce number of DB queries)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,11 @@ Change History
 ------------------
 
 - Fix migration error on MySQL.
+- Add "missing" foreign key indices (with corresponding migration step).
+- Greatly reduce the number of queries that are sent to the DB:
+  - Add caching for the root node.
+  - Use eager / joined loading for local_groups.
+  - Don't query principals for roles
 
 1.1.4 - 2015-06-27
 ------------------

--- a/kotti/alembic/versions/4a3de0d0804a_add_foreignkey_indices.py
+++ b/kotti/alembic/versions/4a3de0d0804a_add_foreignkey_indices.py
@@ -15,11 +15,11 @@ down_revision = '37a05f6246af'
 
 def upgrade():
     op.create_index(
-        'ix_nodes_parent_id', 'nodes', 'parent_id')
+        'ix_nodes_parent_id', 'nodes', ['parent_id', ])
     op.create_index(
-        'ix_local_groups_node_id', 'local_groups', 'node_id')
+        'ix_local_groups_node_id', 'local_groups', ['node_id', ])
     op.create_index(
-        'ix_local_groups_principal_name', 'local_groups', 'principal_name')
+        'ix_local_groups_principal_name', 'local_groups', ['principal_name', ])
 
 
 def downgrade():

--- a/kotti/alembic/versions/4a3de0d0804a_add_foreignkey_indices.py
+++ b/kotti/alembic/versions/4a3de0d0804a_add_foreignkey_indices.py
@@ -1,0 +1,28 @@
+"""Add ForeignKey indices
+
+Revision ID: 4a3de0d0804a
+Revises: 37a05f6246af
+Create Date: 2015-08-31 12:37:26.493958
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '4a3de0d0804a'
+down_revision = '37a05f6246af'
+
+
+def upgrade():
+    op.create_index(
+        'ix_nodes_parent_id', 'nodes', 'parent_id')
+    op.create_index(
+        'ix_local_groups_node_id', 'local_groups', 'node_id')
+    op.create_index(
+        'ix_local_groups_principal_name', 'local_groups', 'principal_name')
+
+
+def downgrade():
+    op.drop_index('ix_nodes_parent_id', 'nodes')
+    op.drop_index('ix_local_groups_node_id', 'local_groups')
+    op.drop_index('ix_local_groups_principal_name', 'local_groups')

--- a/kotti/resources.py
+++ b/kotti/resources.py
@@ -180,10 +180,10 @@ class LocalGroup(Base):
     id = Column(Integer(), primary_key=True)
     #: ID of the node for this assignment
     #: (:class:`sqlalchemy.types.Integer`)
-    node_id = Column(ForeignKey('nodes.id'))
+    node_id = Column(ForeignKey('nodes.id'), index=True)
     #: Name of the principal (user or group)
     #: (:class:`sqlalchemy.types.Unicode`)
-    principal_name = Column(Unicode(100))
+    principal_name = Column(Unicode(100), index=True)
     #: Name of the assigned group or role
     #: (:class:`sqlalchemy.types.Unicode`)
     group_name = Column(Unicode(100))
@@ -224,7 +224,7 @@ class Node(Base, ContainerMixin, PersistentACLMixin):
     type = Column(String(30), nullable=False)
     #: ID of the node's parent
     #: (:class:`sqlalchemy.types.Integer`)
-    parent_id = Column(ForeignKey('nodes.id'))
+    parent_id = Column(ForeignKey('nodes.id'), index=True)
     #: Position of the node within its container / parent
     #: (:class:`sqlalchemy.types.Integer`)
     position = Column(Integer())

--- a/kotti/resources.py
+++ b/kotti/resources.py
@@ -257,6 +257,7 @@ class Node(Base, ContainerMixin, PersistentACLMixin):
         LocalGroup,
         backref=backref('node'),
         cascade='all',
+        lazy='joined',
         )
 
     def __init__(self, name=None, parent=None, title=u"", annotations=None,

--- a/kotti/security.py
+++ b/kotti/security.py
@@ -447,9 +447,13 @@ class Principals(DictMixin):
     """
     factory = Principal
 
-    @request_cache(lambda self, name: name)
+    @request_cache(lambda self, name: unicode(name))
     def __getitem__(self, name):
         name = unicode(name)
+        # avoid calls to the DB for roles
+        # (they're not stored in the ``principals`` table)
+        if name.startswith('role:'):
+            raise KeyError(name)
         try:
             return DBSession.query(
                 self.factory).filter(self.factory.name == name).one()


### PR DESCRIPTION
This supercedes #448.

- add caching for the root node.
- use eager / joined loading for local_groups.
- don't query principals for roles.

These greatly reduce the number of queries that are sent to the DB.  In a default installation of Kotti the number of queries for the default view of ``/demo/foo/`` goes down from 33 to 7.