### PR TITLE
Fix compatibility with bowerstatic and pyramid_layout

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,14 @@ Change History
 1.1.6 - unreleased
 ------------------
 
-- No changes yet.
+- Don't try to set a caching header from the NewRequest handler when Pyramid's
+  tweens didn't follow the usual chain of calls. This fixes compatibility with
+  ``bowerstatic``.
+- Don't assume ``renderer_name`` exists in a rendering event (ex.
+  BeforeRender). The official docstring of ``pyramid.interfaces.IRenderer`` is
+  a bit ambigous in regards to what the ``system`` parameter should include
+  when a renderer gets called. This fixes compatibility with
+  ``pyramid_layout``.
 
 1.1.5 - 2015-09-04
 ------------------

--- a/kotti/tests/test_cache.py
+++ b/kotti/tests/test_cache.py
@@ -66,3 +66,13 @@ class TestSetCacheHeaders:
                 set_cache_headers(event)
 
         assert chooser.call_count == 0
+
+    def test_request_has_no_context(self):
+        from kotti.views.cache import set_cache_headers
+
+        with patch('kotti.views.cache.caching_policy_chooser') as chooser:
+            event = MagicMock()
+            event.request = {}
+            set_cache_headers(event)
+
+            assert chooser.call_count == 0

--- a/kotti/tests/test_util_views.py
+++ b/kotti/tests/test_util_views.py
@@ -522,6 +522,17 @@ class TestViewUtil:
         add_renderer_globals(event)
         assert 'api' in event
 
+    def test_add_renderer_globals_event_has_no_renderer_name(self, db_session):
+        from kotti.views.util import add_renderer_globals
+
+        request = DummyRequest()
+        event = {
+            'request': request,
+            'context': object(),
+            }
+        add_renderer_globals(event)
+        assert 'api' in event
+
 
 class TestLocalNavigationSlot:
     def test_it(self, config, root):

--- a/kotti/views/cache.py
+++ b/kotti/views/cache.py
@@ -103,6 +103,12 @@ def caching_policy_chooser(context, request, response):
 @subscriber(NewResponse)
 def set_cache_headers(event):
     request, response = event.request, event.response
+
+    # this can happen if a Pyramid tween will shortcut the normal tween
+    # chain processing and return its own response early
+    if not hasattr(event.request, 'context'):
+        return
+
     context = event.request.context
 
     # If no caching policy was previously set (by setting the

--- a/kotti/views/util.py
+++ b/kotti/views/util.py
@@ -72,7 +72,7 @@ def template_api(context, request, **kwargs):
 
 
 def add_renderer_globals(event):
-    if event['renderer_name'] != 'json':
+    if event.get('renderer_name') != 'json':
         request = event['request']
         api = getattr(request, 'template_api', None)
         if api is None and request is not None:


### PR DESCRIPTION
This is the problem that this fixes::

<pre>
Traceback (most recent call last):
  File "/home/cruxlog/lib/python2.7/site-packages/waitress/channel.py", line 337, in service
    task.service()
  File "/home/cruxlog/lib/python2.7/site-packages/waitress/task.py", line 173, in service
    self.execute()
  File "/home/cruxlog/lib/python2.7/site-packages/waitress/task.py", line 392, in execute
    app_iter = self.channel.server.application(env, start_response)
  File "/home/cruxlog/lib/python2.7/site-packages/pyramid/router.py", line 242, in __call__
    response = self.invoke_subrequest(request, use_tweens=True)
  File "/home/cruxlog/lib/python2.7/site-packages/pyramid/router.py", line 222, in invoke_subrequest
    has_listeners and notify(NewResponse(request, response))
  File "/home/cruxlog/lib/python2.7/site-packages/pyramid/registry.py", line 74, in notify
    [ _ for _ in self.subscribers(events, None) ]
  File "/home/cruxlog/lib/python2.7/site-packages/zope/interface/registry.py", line 328, in subscribers
    return self.adapters.subscribers(objects, provided)
  File "/home/cruxlog/lib/python2.7/site-packages/zope/interface/adapter.py", line 600, in subscribers
    subscription(*objects)
  File "/home/cruxlog/lib/python2.7/site-packages/pyramid/config/adapters.py", line 103, in derived_subscriber
    return subscriber(arg[0])
  File "/home/cruxlog/src/kotti/kotti/views/cache.py", line 106, in set_cache_headers
    
AttributeError: 'Request' object has no attribute 'context'
</pre>

The pyramid Router.handle_request has not been called by the chain of tweens and as a result the request has no context.