### PR TITLE
WIP on rest views

### DIFF
--- a/kotti/rest.py
+++ b/kotti/rest.py
@@ -1,0 +1,306 @@
+""" JSON Encoders, serializers, REST views and miscellaneous utilities
+
+The main focus of this module are the REST views. You can trigger them by making
+a request with the ACCEPT value of 'application/vnd.api+json' to any Content
+subclass. The HTTP verb used in the request determines the action that is taken.
+
+When making requests and publishing objects, we try to follow the JSONAPI
+format.
+
+To serialize objects to JSON we reuse Colander schemas.  All
+``kotti.resources.Content`` derivates will be automatically serialized, but
+they'll only include the fields in ``ContentSchema``. For custom content types,
+you should write a serializer such as this:
+
+    from kotti.views.edit.content import DocumentSchema
+
+    @serializes(Document)
+    def document_serializer(context, request):
+        return DocumentSchema().serialize(context.__dict__)
+
+This will also register a content factory for types with name 'Document'.
+
+When deserializing (extracting values from request) we reuse the Colander
+schemas to validate those values. Then, these values will be applied to the
+context, in POST and PATCH requests. The REST views also handle GET, PUT and
+DELETE.
+
+TODO: handle exceptions in the REST view. Any exception should be sent as JSON
+response
+TODO: handle permissions/security
+"""
+
+from kotti.resources import Content, Document, File #, IImage
+from kotti.util import _
+from kotti.util import title_to_name
+from pyramid.httpexceptions import HTTPNoContent
+from pyramid.renderers import JSONP
+from pyramid.view import view_config, view_defaults
+from zope.interface import Interface
+import colander
+import datetime
+import decimal
+import json
+import venusian
+
+
+class ISchemaFactory(Interface):
+    """ A factory for colander schemas.
+    """
+
+    def __call__(context, request):
+        """ Returns a colander schema instance """
+
+
+class IContentFactory(Interface):
+    """ A factory for content factories. Can be a class, ex: Document
+    """
+
+    def __call__(context, request):
+        """ Returns a factory that can construct a new object """
+
+
+def _schema_factory_name(context=None, type_name=None, name=u'default'):
+
+    if not any([context, type_name]):
+        raise Exception("Provide a context or a type name")
+
+    if (context is not None) and (type_name is None):
+        type_name = context.type_info.name
+
+    return u"{}/{}".format(type_name, name)
+
+
+def schema_factory(klass, name=u'default'):
+    """ A decorator to be used to mark a function as a serializer.
+
+    The decorated function should return a basic python structure usable (along
+    the lines of colander's cstruct) by a JSON encoder.
+
+    It will also register the context class as a factory for that content.
+    """
+
+    name = _schema_factory_name(context=klass, name=name)
+
+    def wrapper(wrapped):
+        def callback(context, funcname, ob):
+            config = context.config.with_package(info.module)
+            config.registry.registerUtility(wrapped, ISchemaFactory, name=name)
+            config.registry.registerUtility(klass, IContentFactory,
+                                            name=klass.type_info.name)
+
+        info = venusian.attach(wrapped, callback, category='pyramid')
+        return wrapped
+
+    return wrapper
+
+
+@schema_factory(Content)
+def content_serializer(context, request):
+    from kotti.views.edit.content import ContentSchema
+    return ContentSchema()
+
+
+@schema_factory(Document)
+def document_serializer(context, request):
+    from kotti.views.edit.content import DocumentSchema
+    return DocumentSchema()
+
+
+@schema_factory(File)
+def file_serializer(context, request):
+    from kotti.views.edit.content import FileSchema
+    return FileSchema(None)
+
+
+ACCEPT = 'application/vnd.api+json'
+
+
+@view_defaults(name='', accept=ACCEPT, renderer="kotti_jsonp")
+class RestView(object):
+    """ A generic @@json view for any and all contexts.
+
+    Its response depends on the HTTP verb used. For ex:
+    """
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    @view_config(request_method='GET')
+    def get(self):
+        return self.context
+
+    @view_config(request_method='POST')
+    def post(self):
+        data = self.request.json_body['data']
+
+        assert data['id'] == self.context.name
+        assert data['type'] == self.context.type_info.name
+
+        schema = schema_factory(self.context, name='edit')(
+            self.context, self.request)
+        validated = schema.deserialize(data['attributes'])
+
+        for k, v in validated.items():
+            setattr(self.context, k, v)
+
+        return self.context
+
+    @view_config(request_method='PATCH')
+    def patch(self):
+        data = self.request.json_body['data']
+
+        assert data['id'] == self.context.name
+        assert data['type'] == self.context.type_info.name
+
+        schema = get_schema(self.context, self.request)
+        validated = schema.deserialize(data['attributes'])
+        attrs = dict((k, v) for k, v in validated.items()
+                     if k in data['attributes'])
+        for k, v in attrs.items():
+            setattr(self.context, k, v)
+
+        return self.context
+
+    @view_config(request_method='PUT')
+    def put(self):
+        # we never accept id, it doesn't conform to jsonapi format
+        data = self.request.json_body['data']
+
+        name=_schema_factory_name(type_name=data['type'])
+        schema_factory = self.request.registry.getUtility(ISchemaFactory,
+                                                          name=name)
+        schema = schema_factory(None, self.request)
+        validated = schema.deserialize(data['attributes'])
+
+        klass = get_factory(self.request, data['type'])
+        name = title_to_name(validated['title'], blacklist=self.context.keys())
+        new_item = self.context[name] = klass(**validated)
+
+        return new_item
+
+    @view_config(request_method='DELETE')
+    def delete(self):
+        parent = self.context.__parent__
+        del parent[self.context.__name__]
+        return HTTPNoContent()
+
+
+def get_schema(obj, request, name=u'default'):
+    factory_name = _schema_factory_name(context=obj, name=name)
+    schema_factory = request.registry.getUtility(ISchemaFactory,
+                                                 name=factory_name)
+    return schema_factory(obj, request)
+
+
+def get_factory(request, name):
+    return request.registry.getUtility(IContentFactory, name=name)
+
+
+# def filter_schema(schema, allowed_fields):
+#     """ Filters a schema to include only allowed fields
+#     """
+#
+#     cloned = schema.__class__(self.typ)
+#     cloned.__dict__.update(schema.__dict__)
+#     cloned.children = [node.clone() for node in self.children
+#                        if node.name in allowed_fields]
+#     return cloned
+#
+
+class MetadataSchema(colander.MappingSchema):
+    """ Schema that exposes some metadata information about a content
+    """
+
+    modification_date = colander.SchemaNode(
+        colander.Date(),
+        title=_(u'Modification Date'),
+    )
+
+    creation_date = colander.SchemaNode(
+        colander.Date(),
+        title=_(u'Modification Date'),
+    )
+
+    state = colander.SchemaNode(
+        colander.String(),
+        title=_(u'State'),
+    )
+    state = colander.SchemaNode(
+        colander.String(),
+        title=_(u'State'),
+    )
+
+    default_view = colander.SchemaNode(
+        colander.String(),
+        title=_(u'Default view'),
+    )
+
+    in_navigation = colander.SchemaNode(
+        colander.String(),
+        title=_(u'In navigation'),
+    )
+
+
+def serialize(obj, request, name=u'default'):
+    """ Serialize a Kotti content item.
+
+    The response JSON conforms with JSONAPI standard.
+
+    TODO: implement JSONAPI filtering and pagination.
+    """
+    data = get_schema(obj, request, name).serialize(obj.__dict__)
+
+    res = {}
+    res['type'] = obj.type_info.name
+    res['id'] = obj.__name__
+    res['attributes'] = data
+    res['links'] = {
+        'self': request.resource_url(obj),
+        'children': [request.resource_url(child)
+                     for child in obj.children_with_permission(request)]
+    }
+    meta = MetadataSchema().serialize(obj.__dict__)
+
+    return dict(data=res, meta=meta)
+
+
+def _encoder(basedefault):
+    """ A JSONEncoder that can encode some basic odd objects.
+
+    For most objects it will execute the basedefault function, which uses
+    adapter lookup mechanism to achieve the encoding, but for some basic
+    objects, such as datetime and colander.null we solve it here.
+    """
+
+    class Encoder(json.JSONEncoder):
+
+        def default(self, obj):
+            """Convert ``obj`` to something JSON encoder can handle."""
+            # if isinstance(obj, NamedTuple):
+            #     obj = dict((k, getattr(obj, k)) for k in obj.keys())
+            if isinstance(obj, decimal.Decimal):
+                return str(obj)
+            elif isinstance(obj,
+                            (datetime.time, datetime.date, datetime.datetime)):
+                return str(obj)
+            elif obj is colander.null:
+                return None
+
+            return basedefault(obj)
+
+    return Encoder
+
+
+def to_json(obj, default=None, **kw):
+    return json.dumps(obj, cls=_encoder(default), **kw)
+
+
+jsonp = JSONP(param_name='callback', serializer=to_json)
+jsonp.add_adapter(Content, serialize)
+
+
+def includeme(config):
+    config.add_renderer('kotti_jsonp', jsonp)
+    config.scan(__name__)

--- a/kotti/tests/test_rest.py
+++ b/kotti/tests/test_rest.py
@@ -1,0 +1,212 @@
+from kotti.resources import TypeInfo, Content, Document
+from kotti.rest import schema_factory
+from kotti.testing import DummyRequest
+from sqlalchemy import Column, ForeignKey, Integer
+import colander
+import json
+
+
+class Something(Content):
+    id = Column(Integer(), ForeignKey('contents.id'), primary_key=True)
+    type_info = TypeInfo(name="Something")
+
+
+@schema_factory(Something)
+def sa(context, request):
+    return 'a'
+
+
+@schema_factory(Something, name='b')
+def sb(context, request):
+    return 'b'
+
+
+class TestSerializer:
+
+    def test_serializes_decorator(self, config):
+        from kotti.rest import ISchemaFactory
+        from zope.component import getUtility
+
+        config.scan('kotti.tests.test_rest')
+        obj, req = Something(), DummyRequest()
+
+        assert getUtility(ISchemaFactory,
+                          name='Something/default')(obj, req) == 'a'
+        assert getUtility(ISchemaFactory,
+                          name='Something/b')(obj, req) == 'b'
+
+
+# TODO: test content factories
+
+
+class TestSerializeDefaultContent:
+
+    def make_one(self, config, klass=Content, **kw):
+        from kotti.rest import serialize
+
+        config.scan('kotti.rest')
+
+        props = {
+            'name': 'doc-a',
+            'title': u'Doc A',
+            'description': u'desc...'
+        }
+        props.update(**kw)
+        obj = klass(**props)
+        return serialize(obj, DummyRequest())
+
+    def test_serialize_content(self, config):
+        from kotti.resources import Content
+        resp = self.make_one(config, klass=Content)
+        assert resp['data']['id'] == u'doc-a'
+        assert resp['data']['attributes']['title'] == u'Doc A'
+        assert resp['data']['attributes']['description'] == u'desc...'
+        assert resp['data']['attributes']['tags'] == colander.null
+
+    def test_serialize_document(self, config):
+        resp = self.make_one(config, Document, body=u'Body text')
+        assert resp['data']['attributes']['body'] == u'Body text'
+
+    def test_serialize_file(self, config, filedepot):
+        from kotti.resources import File
+        res = self.make_one(config, File, data='file content')
+        assert res  # TODO: finish
+
+    # TODO: serializing an image
+
+
+class TestRestView:
+
+    def _make_request(self, config, **kw):
+        from kotti.rest import ACCEPT
+        from webob.acceptparse import MIMEAccept
+        from pyramid.request import Request
+
+        _environ = {
+            'PATH_INFO': '/',
+            'SERVER_NAME': 'example.com',
+            'SERVER_PORT': '80',
+            'wsgi.url_scheme': 'http',
+            'REQUEST_METHOD': 'PATCH'
+            }
+        _environ.update(**kw)
+
+        req = Request(accept=MIMEAccept(ACCEPT), environ=_environ)
+        req.registry = config.registry
+        return req
+
+    def _get_view(self, context, request, name=''):
+        from pyramid.compat import map_
+        from pyramid.interfaces import IView
+        from pyramid.interfaces import IViewClassifier
+        from zope.interface import providedBy
+
+        provides = [IViewClassifier] + map_(
+            providedBy,
+            (request, context)
+        )
+
+        return request.registry.adapters.lookup(provides, IView, name=name)
+
+    def test_get(self, config):
+        from kotti.rest import ACCEPT
+        from webob.acceptparse import MIMEAccept
+
+        config.include('kotti.rest')
+
+        req = DummyRequest(accept=MIMEAccept(ACCEPT))
+        doc = Document()
+
+        view = self._get_view(doc, req)
+        data = view(doc, req).json_body
+
+        assert 'attributes' in data['data']
+        assert 'meta' in data
+
+    def test_jsonp_as_renderer(self, config):
+        from pyramid.renderers import render
+
+        config.include('kotti.rest')
+
+        doc = Document('1')
+        req = DummyRequest()
+
+        js = json.loads(render('kotti_jsonp', doc, request=req))
+        assert js['data']['attributes']['body'] == "1"
+
+    def test_put(self, config):
+        config.include('kotti.rest')
+        req = self._make_request(config, REQUEST_METHOD='PUT')
+        req.body = json.dumps({
+            'data': {
+                'type': 'Document',
+                'attributes': {
+                    'title': u"Title here",
+                    'body': u"Body here"
+                }
+            }
+        })
+        doc = Document(name='parent')
+        view = self._get_view(doc, req)
+        data = view(doc, req).json_body['data']
+
+        assert data['attributes']['title'] == u'Title here'
+        assert data['id'] == 'title-here'
+
+        assert doc.keys() == ['title-here']
+
+    def test_patch(self, config):
+
+        config.include('kotti.rest')
+
+        doc = Document(name='first',
+                       title=u'Title here',
+                       description=u"Description here",
+                       body=u"body here")
+
+        req = self._make_request(config)
+        req.body = json.dumps({
+            'data': {
+                'id': 'first',
+                'type': 'Document',
+                'attributes': {
+                    'title': u"Title was changed",
+                    'body': u"Body was changed"
+                }
+            }
+        })
+
+        view = self._get_view(doc, req)
+        data = view(doc, req).json_body
+
+        assert data['data']['attributes']['title'] == u"Title was changed"
+        assert data['data']['attributes']['body'] == u"Body was changed"
+
+    def test_post(self, config):
+
+        config.include('kotti.rest')
+
+        doc = Document(name='first',
+                       title=u'Title here',
+                       description=u"Description here",
+                       body=u"body here")
+
+        req = self._make_request(config)
+        req.body = json.dumps({
+            'data': {
+                'id': 'first',
+                'type': 'Document',
+                'attributes': {
+                    'title': u"Title was changed",
+                    'body': u"Body was changed"
+                }
+            }
+        })
+
+        view = self._get_view(doc, req)
+        data = view(doc, req).json_body
+
+        assert data['data']['attributes']['title'] == u"Title was changed"
+        assert data['data']['attributes']['body'] == u"Body was changed"
+
+    # TODO: test delete method


### PR DESCRIPTION
I'm creating this PR to create discussions on a possible way to implement JSON views.

The main idea is to have generic JSON views for all kotti resources while making it easy to integrate this framework with other third party content types.

For this we have:

* a set of JSON views. We would have a default view (named "") that only treats the ACCEPT='application/vnd.api+json' requests. It would offer default implementations for GET, POST, PUT, PATCH and DELETE. They all deal with getting and changing the "context" of the view.
* a way to automatically serialize database content. This is where it gets hairy. We need a "schema factory" content instead of a dotted path to a class Schema because, for example, the FileSchema is built by a function that receives the request parameter. We'll probably don't use that to serialize Files, but this just highlights a problem that may appear in third party code.
* we need content factories, for the PUT operation. In my code I've overloaded the @schema_factory decorater  to also register the content factory, so a better name is needed.

There's still a lot to be implemented before the PR is complete, like pagination, filtering, security, better testing, etc.