### PR TITLE
Restore '--statistics' and '--no-wrap' options when invoking gettext tools

### DIFF
--- a/i18n.sh
+++ b/i18n.sh
@@ -30,12 +30,13 @@ if [ $# -eq 0 ]; then
 
     echo "Update translations"
     for po in "$LOCALES_PATH"/*/LC_MESSAGES/$DOMAIN.po; do
-        msgmerge -o "$po" "$po" "$LOCALES_PATH"/$DOMAIN.pot
+        msgmerge --no-wrap -o "$po" "$po" "$LOCALES_PATH"/$DOMAIN.pot
     done
 
     echo "Compile message catalogs"
     for po in "$LOCALES_PATH"/*/LC_MESSAGES/*.po; do
-        msgfmt -o "${po%.*}.mo" "$po"
+        echo "Compiling file $po..."
+        msgfmt --statistics -o "${po%.*}.mo" "$po"
     done
 
 # first argument represents language identifier, create catalog


### PR DESCRIPTION
Added '--statistics' option to invocation of `msgfmt` to bring attention to possible fuzzy translations; see https://github.com/wichert/lingua/issues/59
Additionally now we print file being currently compiled so that we know which statistic is
for which language.
Added '--no-wrap' option to invocation of `msgmerge` to avoid wrapping original
msgids. Wrapping needlessly "mangles" original msgids.
Please note that both options were lost during migration to lingua 3.6.1 in commit
https://github.com/Kotti/Kotti/commit/285bad5