### PR TITLE
RFC: add ``kotti.modification_date_excludes`` configuration option

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,10 @@ Change History
   a bit ambigous in regards to what the ``system`` parameter should include
   when a renderer gets called. This fixes compatibility with
   ``pyramid_layout``.
+- Add a ``kotti.modification_date_excludes`` configuration option.
+  It takes a list of attributes in dotted name notation that should not trigger
+  an update of ``modification_date`` on change.  Defaults to
+  ``kotti.resources.Node.position``.
 
 1.1.5 - 2015-09-04
 ------------------

--- a/docs/developing/basic/configuration.rst
+++ b/docs/developing/basic/configuration.rst
@@ -37,52 +37,54 @@ Overview of settings
 This table provides an overview of available settings.
 All these settings must go into the ``[app:kotti]`` section of your Paste Deploy configuration file.
 
-============================  ==================================================
-Setting                       Description
-============================  ==================================================
-**kotti.site_title**          The title of your site
-**kotti.secret**              Secret token used for the initial admin password
-kotti.secret2                 Secret token used for email password reset token
-
-**sqlalchemy.url**            `SQLAlchemy database URL`_
-**mail.default_sender**       Sender address for outgoing email
-mail.host                     Email host to send from
-
-pyramid.includes              List of Python configuration hooks
-kotti.available_types         List of active content types
-kotti.base_includes           List of base Python configuration hooks
-kotti.zcml_includes           List of packages to include the ZCML from
-kotti.configurators           List of advanced functions for config
-kotti.request_factory         Override Kotti's default request factory
-kotti.root_factory            Override Kotti's default Pyramid *root factory*
-kotti.populators              List of functions to fill initial database
-kotti.search_content          Override Kotti's default search function
-
-kotti.asset_overrides         Override Kotti's templates
-kotti.templates.api           Override ``api`` object available in templates
-kotti.fanstatic.view_needed   List of static resources used for public interface
-kotti.fanstatic.edit_needed   List of static resources used for edit interface
-
-kotti.authn_policy_factory    Component used for authentication
-kotti.authz_policy_factory    Component used for authorization
-kotti.session_factory         Component used for sessions
-
-kotti.caching_policy_chooser  Component for choosing the cache header policy
-kotti.url_normalizer          Component used for url normalization
-
-kotti.date_format             Date format to use, default: ``medium``
-kotti.datetime_format         Datetime format to use, default: ``medium``
-kotti.time_format             Time format to use, default: ``medium``
-kotti.max_file_size           Max size for file uploads, default: ```10`` (MB)
-
-kotti.depot.*.*               Configure the blob storage. More details below
-
-kotti.sanitizers              Configure available :ref:`sanitizers`.
-kotti.sanitize_on_write       Configure :ref:`sanitizers` to be used on write
-                              access to resource objects.
-
-pyramid.default_locale_name   Set the user interface language, default ``en``
-============================  ==================================================
+================================  ==============================================
+Setting                           Description
+================================  ==============================================
+**kotti.site_title**              The title of your site
+**kotti.secret**                  Secret token used for the initial admin
+                                  password
+kotti.secret2                     Secret token used for email password reset
+                                  token
+**sqlalchemy.url**                `SQLAlchemy database URL`_
+**mail.default_sender**           Sender address for outgoing email
+mail.host                         Email host to send from
+pyramid.includes                  List of Python configuration hooks
+kotti.available_types             List of active content types
+kotti.base_includes               List of base Python configuration hooks
+kotti.zcml_includes               List of packages to include the ZCML from
+kotti.configurators               List of advanced functions for config
+kotti.request_factory             Override Kotti's default request factory
+kotti.root_factory                Override Kotti's default Pyramid
+                                  *root factory*
+kotti.populators                  List of functions to fill initial database
+kotti.search_content              Override Kotti's default search function
+kotti.asset_overrides             Override Kotti's templates
+kotti.templates.api               Override ``api`` object available in
+                                  templates
+kotti.fanstatic.view_needed       List of static resources used for public
+                                  interface
+kotti.fanstatic.edit_needed       List of static resources used for edit
+                                  interface
+kotti.authn_policy_factory        Component used for authentication
+kotti.authz_policy_factory        Component used for authorization
+kotti.session_factory             Component used for sessions
+kotti.caching_policy_chooser      Component for choosing the cache header policy
+kotti.url_normalizer              Component used for url normalization
+kotti.date_format                 Date format to use, default: ``medium``
+kotti.datetime_format             Datetime format to use, default: ``medium``
+kotti.time_format                 Time format to use, default: ``medium``
+kotti.max_file_size               Max size for file uploads,
+                                  default: ```10`` (MB)
+kotti.modification_date_excludes  List of attributes in dotted name notation
+                                  that should not trigger an update of
+                                  ``modification_date`` on change.
+kotti.depot.*.*                   Configure the blob storage. More details below
+kotti.sanitizers                  Configure available :ref:`sanitizers`.
+kotti.sanitize_on_write           Configure :ref:`sanitizers` to be used on
+                                  write access to resource objects.
+pyramid.default_locale_name       Set the user interface language,
+                                  default ``en``
+================================  ==============================================
 
 Only the settings in bold letters required.
 The rest has defaults.
@@ -317,18 +319,18 @@ Blob storage configuration
 --------------------------
 
 By default, Kotti will store blob data (files uploaded in File and Image instances) in the database.
-Internally, Kotti integrates with :app:`filedepot`, so it is possible to use any :app:`filedepot` compatible storage, including those provided by :app:`filedepot` itself:
+Internally, Kotti integrates with ``filedepot``, so it is possible to use any ``filedepot`` compatible storage, including those provided by ``filedepot`` itself:
 
 - :class:`depot.io.local.LocalFileStorage`
 - :class:`depot.io.awss3.S3Storage`
 - :class:`depot.io.gridfs.GridFSStorage`
 
-The default storage for :app:`Kotti` is :class:`~kotti.filedepot.DBFileStorage`.
+The default storage for Kotti is :class:`~kotti.filedepot.DBFileStorage`.
 The benefit of storing files in ``DBFileStorage`` is having *all* content in a single place (the DB) which makes backups, exporting and importing of your site's data easy, as long as you don't have too many or too large files.
 The downsides of this approach appear when your database server resides on a different host (network performance becomes a greater issue) or your DB dumps become too large to be handled efficiently.
 
 To configure a depot, several ``kotti.depot.*.*`` lines need to be added.
-The number in the first position is used to group backend configuration and to order the file storages in the configuration of :app:`filedepot`.
+The number in the first position is used to group backend configuration and to order the file storages in the configuration of ``filedepot``.
 The depot configured with number 0 will be the default depot, where all new blob data will be saved.
 There are 2 options that are required for every storage configuration: ``name`` and ``backend``.
 The ``name`` is a unique string that will be used to identify the path of saved files (it is recorded with each blob info), so once configured for a particular storage, it should never change.
@@ -336,7 +338,7 @@ The ``backend`` should point to a dotted path for the storage class.
 Then, any number of keyword arguments can be added, and they will be passed to the backend class on initialization.
 
 Example of a possible configurationi that stores blob data on the disk, in
-``/var/local/files`` using the :app:`filedepot` :class:`depot.io.local.LocalFileStorage` provided backend.
+``/var/local/files`` using the ``filedepot`` :class:`depot.io.local.LocalFileStorage` provided backend.
 Kotti's default backend, ``DBFileStorage`` has been moved to position **1** and all data stored there will continue to be available.
 See :ref:`blobs` to see how to migrate blob data between storages.
 

--- a/docs/developing/basic/security.rst
+++ b/docs/developing/basic/security.rst
@@ -108,9 +108,10 @@ The default workflow is quite useful for websites, but sometimes you need someth
 Just point the ``kotti.use_workflow`` setting to your zcml file:
 
 .. code-block:: ini
+
     kotti.use_workflow = kotti_yourplugin:workflow.zcml
 
-The simplest way to deal with workflow definitions is::
+The simplest way to deal with workflow definitions is:
 
 1. create a copy of the default workflow definition and
 2. customize it (change permissions, add new states, permissions, transitions, initial state and so on).
@@ -252,6 +253,7 @@ Here it is, our "custom" workflow definition assigned to our ``ICustomContent`` 
 Last you have to tell Kotti to register your new custom workflow including our ``zcml`` file:
 
 .. code-block:: ini
+
     kotti.zcml_includes = kotti_wf:workflow.zcml
 
 Special cases:

--- a/kotti/__init__.py
+++ b/kotti/__init__.py
@@ -92,6 +92,9 @@ conf_defaults = {
     'kotti.fanstatic.edit_needed': 'kotti.fanstatic.edit_needed',
     'kotti.fanstatic.view_needed': 'kotti.fanstatic.view_needed',
     'kotti.max_file_size': '10',
+    'kotti.modification_date_excludes': ' '.join([
+        'kotti.resources.Node.position',
+    ]),
     'kotti.populators': 'kotti.populate.populate',
     'kotti.principals_factory': 'kotti.security.principals_factory',
     'kotti.register': 'False',
@@ -134,6 +137,7 @@ conf_dotted = set([
     'kotti.configurators',
     'kotti.fanstatic.edit_needed',
     'kotti.fanstatic.view_needed',
+    'kotti.modification_date_excludes',
     'kotti.populators',
     'kotti.principals_factory',
     'kotti.request_factory',

--- a/kotti/events.py
+++ b/kotti/events.py
@@ -23,11 +23,13 @@ import sqlalchemy.event
 from sqlalchemy.orm import load_only
 import venusian
 from sqlalchemy.orm import mapper
+from sqlalchemy_utils.functions import has_changes
 from pyramid.location import lineage
 from pyramid.threadlocal import get_current_request
 from zope.deprecation.deprecation import deprecated
 
 from kotti import DBSession
+from kotti import get_settings
 from kotti.resources import Content
 from kotti.resources import LocalGroup
 from kotti.resources import Node
@@ -255,7 +257,14 @@ def set_modification_date(event):
     :type event: :class:`ObjectUpdate`
     """
 
-    event.object.modification_date = datetime.now()
+    exclude = []
+
+    for e in get_settings()['kotti.modification_date_excludes']:
+        if isinstance(event.object, e.class_):
+            exclude.append(e.key)
+
+    if has_changes(event.object, exclude=exclude):
+        event.object.modification_date = datetime.now()
 
 
 def delete_orphaned_tags(event):

--- a/kotti/security.py
+++ b/kotti/security.py
@@ -82,10 +82,6 @@ class Principal(Base):
         receiver of the email.  This attribute should be set to
         'None' once confirmation has succeeded.
     """
-    __tablename__ = 'principals'
-    __mapper_args__ = dict(
-        order_by='principals.name',
-        )
 
     id = Column(Integer, primary_key=True)
     name = Column(Unicode(100), unique=True)
@@ -97,6 +93,11 @@ class Principal(Base):
     groups = Column(MutationList.as_mutable(JsonType), nullable=False)
     creation_date = Column(DateTime(), nullable=False)
     last_login_date = Column(DateTime())
+
+    __tablename__ = 'principals'
+    __mapper_args__ = dict(
+        order_by=name,
+        )
 
     def __init__(self, name, password=None, active=True, confirm_token=None,
                  title=u"", email=None, groups=None):

--- a/kotti/tests/test_app.py
+++ b/kotti/tests/test_app.py
@@ -8,7 +8,9 @@ from pyramid.interfaces import IView
 from pyramid.interfaces import IViewClassifier
 from pyramid.request import Request
 from pyramid.threadlocal import get_current_registry
+from sqlalchemy import column
 from sqlalchemy import select
+from sqlalchemy import table
 from zope.interface import implementedBy
 from zope.interface import providedBy
 
@@ -208,7 +210,8 @@ class TestApp:
                 main({}, **settings)
 
         res = db_session.execute(select(
-            columns=['version_num'], from_obj=['kotti_alembic_version']))
+            columns=[column('version_num')],
+            from_obj=[table('kotti_alembic_version')]))
         assert tuple(res)  # a version_num should exist
 
 

--- a/kotti/tests/test_events.py
+++ b/kotti/tests/test_events.py
@@ -132,3 +132,34 @@ class TestEvents:
         assert (handler, dec.register, 'kotti') in dec.venusian.attached
         assert handler not in listeners[ObjectEvent]
         assert handler in objectevent_listeners[(ObjectEvent, Document)]
+
+    def test_set_modification_date(self, root, db_session, events):
+
+        from time import sleep
+        from kotti.resources import Document
+
+        # create 2 documents
+        d1 = root['d1'] = Document(title='One')
+        d2 = root['d2'] = Document(title='Two')
+        assert d1.position == 0
+        assert d2.position == 1
+        db_session.flush()
+        md1 = d1.modification_date
+        md2 = d2.modification_date
+
+        # changing positions should not update modification_date
+        sleep(1)
+        d1.position = 1
+        d2.position = 0
+        db_session.flush()
+        assert d1.position == 1
+        assert d2.position == 0
+        assert d1.modification_date == md1
+        assert d2.modification_date == md2
+
+        # changing anything else should update modification_date
+        d1.title = 'Eins'
+        d2.title = 'Zwei'
+        db_session.flush()
+        assert d1.modification_date != md1
+        assert d2.modification_date != md2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ PasteDeploy==1.5.2
 Pillow==2.9.0
 Pygments==2.0.2
 SQLAlchemy==1.0.8
+SQLAlchemy-Utils==0.31.0
 Unidecode==0.04.18
 WebOb==1.4.1
 alembic==0.8.2

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ install_requires = [
     'Babel',
     'Chameleon>=2.7.4',  # Fixes error when raising HTTPFound
     'Pillow',  # dependency of plone.scale
-    'alembic',
+    'alembic>=0.8.0',
     'bleach',
     'bleach-whitelist',
     'colander>=0.9.3',
@@ -49,7 +49,8 @@ install_requires = [
     'pyramid_zcml',
     'repoze.lru',
     'repoze.workflow',
-    'sqlalchemy>=0.7.6',
+    'sqlalchemy>=1.0.0',
+    'sqlalchemy-utils',
     'transaction>=1.1.0',
     'unidecode',
     'usersettings',


### PR DESCRIPTION
Currently ``Node.modfication_date`` is updated on **every** change to a node.  This is by default at least undesirable for updates to the ``position`` attribute, in custom applications probably also for other attributes.

This PR introduces a new configuration option that takes a list of attributes that should be ignored w.r.t. changes when ``modification_date`` is to be updated via the ``set_modification_date`` event handler.