### PR TITLE
Restore '--statistics' and '--no-wrap' options when invoking gettext tools.

### DIFF
--- a/kotti/scaffolds/package/i18n.sh_tmpl
+++ b/kotti/scaffolds/package/i18n.sh_tmpl
@@ -30,12 +30,13 @@ if [ $# -eq 0 ]; then
 
     echo "Update translations"
     for po in "$LOCALES_PATH"/*/LC_MESSAGES/$DOMAIN.po; do
-        msgmerge -o "$po" "$po" "$LOCALES_PATH"/$DOMAIN.pot
+        msgmerge --no-wrap -o "$po" "$po" "$LOCALES_PATH"/$DOMAIN.pot
     done
 
     echo "Compile message catalogs"
     for po in "$LOCALES_PATH"/*/LC_MESSAGES/*.po; do
-        msgfmt -o "${po%.*}.mo" "$po"
+        echo "Compiling file $po..."
+        msgfmt --statistics -o "${po%.*}.mo" "$po"
     done
 
 # first argument represents language identifier, create catalog


### PR DESCRIPTION
This brings changes to Kotti's own i18n.sh script (PR #453) to scaffold.