### PR TITLE
Extract texts for translation only from project's own domain.

### DIFF
--- a/i18n.sh
+++ b/i18n.sh
@@ -26,7 +26,7 @@ fi
 # no arguments, extract and update
 if [ $# -eq 0 ]; then
     echo "Extract messages"
-    pot-create "$SEARCH_PATH" -o "$LOCALES_PATH"/$DOMAIN.pot
+    pot-create "$SEARCH_PATH" -d $DOMAIN -o "$LOCALES_PATH"/$DOMAIN.pot
 
     echo "Update translations"
     for po in "$LOCALES_PATH"/*/LC_MESSAGES/$DOMAIN.po; do

--- a/kotti/scaffolds/package/i18n.sh_tmpl
+++ b/kotti/scaffolds/package/i18n.sh_tmpl
@@ -26,7 +26,7 @@ fi
 # no arguments, extract and update
 if [ $# -eq 0 ]; then
     echo "Extract messages"
-    pot-create "$SEARCH_PATH" -o "$LOCALES_PATH"/$DOMAIN.pot
+    pot-create "$SEARCH_PATH" -d $DOMAIN -o "$LOCALES_PATH"/$DOMAIN.pot
 
     echo "Update translations"
     for po in "$LOCALES_PATH"/*/LC_MESSAGES/$DOMAIN.po; do


### PR DESCRIPTION
This prevents needless extraction of texts in overridden templates.