### PR TITLE
added list method for newer versions of filedepot

### DIFF
--- a/kotti/filedepot.py
+++ b/kotti/filedepot.py
@@ -283,6 +283,10 @@ class DBFileStorage(FileStorage):
         return bool(
             DBSession.query(DBStoredFile).filter_by(file_id=file_id).count())
 
+    def list(self, *args):
+        raise NotImplementedError, "list() method is unimplemented."
+    
+
     def _get_file_id(self, file_or_id):
         if hasattr(file_or_id, 'file_id'):
             return file_or_id.file_id

--- a/kotti/filedepot.py
+++ b/kotti/filedepot.py
@@ -227,8 +227,8 @@ class DBFileStorage(FileStorage):
         Given a :class:`StoredFile` or its ID it will replace the current
         content with the provided ``content`` value. If ``filename`` and
         ``content_type`` are provided or can be deducted by the ``content``
-        itself they will also replace the previous values, otherwise the current
-        values are kept.
+        itself they will also replace the previous values, otherwise
+        the current values are kept.
 
         :param file_or_id: can be either ``DBStoredFile`` or a ``file_id``
 
@@ -284,8 +284,7 @@ class DBFileStorage(FileStorage):
             DBSession.query(DBStoredFile).filter_by(file_id=file_id).count())
 
     def list(self, *args):
-        raise NotImplementedError, "list() method is unimplemented."
-    
+        raise NotImplementedError("list() method is unimplemented.")
 
     def _get_file_id(self, file_or_id):
         if hasattr(file_or_id, 'file_id'):


### PR DESCRIPTION
Having an [abstract method](https://github.com/amol-/depot/commit/e4eb38cfcf3042d7bb39a1c66c7ecbbb32d79177#diff-c54e8dad3bdef5e4b1c1734be8b72509R213) defined on the interface forces subclasses to at least have the method present, even if unimplemented.



[filedepot commit](https://github.com/amol-/depot/commit/e4eb38cfcf3042d7bb39a1c66c7ecbbb32d79177#diff-c54e8dad3bdef5e4b1c1734be8b72509R213)

