### PR TITLE
Use generic SQLAlchemy type Text as base type for JsonType

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,19 @@ Change History
 
 - Fix or ignore some PyCharm inspection warnings.
 
+- Use generic SQLAlchemy type Text as base type for JsonType. This allows
+  SQLAlchemy to map Text type to the most suitable type available on given
+  database system. Previously used TEXT type is not available in Oracle
+  database. In case of existing installation of Kotti with database system,
+  for which SQLAlchemy maps generic Text type to type different than TEXT it's
+  necessary to either convert existing columns "nodes._acl" and
+  "nodes.annotations" to that type or configure SQLAlchemy to map generic Text
+  type to existing type of these two columns. For example of how to do this
+  please see http://stackoverflow.com/a/36506666/95735. For all database
+  systems for which SQLAlchemy provides dialects except Oracle (Firebird,
+  Microsoft SQL Server, MySQL, Postgres, SQLite, Sybase) there's no need to
+  do anything.
+
 1.3.0-alpha.4 - 2015-01-15
 --------------------------
 

--- a/kotti/sqla.py
+++ b/kotti/sqla.py
@@ -13,7 +13,7 @@ from pyramid.security import Allow
 from sqlalchemy.ext import baked
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.mutable import Mutable
-from sqlalchemy.types import TypeDecorator, TEXT
+from sqlalchemy.types import TypeDecorator, Text
 
 bakery = baked.bakery()
 baked.bake_lazy_loaders()
@@ -38,7 +38,7 @@ def no_autoflush(func):
 class JsonType(TypeDecorator):
     """http://www.sqlalchemy.org/docs/core/types.html#marshal-json-strings
     """
-    impl = TEXT
+    impl = Text
 
     # noinspection PyMethodOverriding
     @staticmethod


### PR DESCRIPTION
Use generic SQLAlchemy type Text as base type for JsonType instead of TEXT type which is not supported in Oracle. Text type is translated to CLOB type in Oracle.