### PR TITLE
make workflow change dropdown to appears depend on state_change permission instead of edit

### DIFF
--- a/kotti/templates/editor-bar.pt
+++ b/kotti/templates/editor-bar.pt
@@ -13,7 +13,7 @@
     </div>
     <div class="collapse navbar-collapse" id="navbar-edit">
       <ul class="nav navbar-nav navbar-left">
-        <tal:condition tal:condition="api.has_permission('edit')">
+        <tal:condition tal:condition="api.has_permission('state_change')">
           <li tal:replace="api.render_view('workflow-dropdown')" />
         </tal:condition>
 


### PR DESCRIPTION
Seems like bug to me. For some custom workflow I want to let user to change the item workflow state but not to edit the item itself. The code as it was wasn't preventing workflow from changing, but hide the state change option from  nav-bar.

Thank you for awesome framework :)
