### PR TITLE
Use potentially overridden request class

### DIFF
--- a/kotti/views/slots.py
+++ b/kotti/views/slots.py
@@ -64,7 +64,7 @@ def _render_view_on_slot_event(view_name, event, params):
     context = event.object
     request = event.request
 
-    view_request = Request.blank(
+    view_request = request.blank(
         "{0}/{1}".format(request.path.rstrip('/'), view_name),
         base_url=request.application_url,
         POST=_encode(params))


### PR DESCRIPTION
We can't hardcode here `Request` as the request class as users are free to provide their own request class by means of `kotti.request_factory` setting.
