### PR TITLE
In contentfactories view, test if add_view is None on all content factories

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,9 @@ Change History
 1.3.1.dev0 - unreleased
 -----------------------
 
-- No changes yet.
+- Bugfix: when showing addable content in the menu, check if the factory has
+  a defined add_view. This avoids a hard crash with, for example, a content
+  type derived from Content that has no add_view defined.
 
 1.3.0 - 2016-10-10
 ------------------

--- a/kotti/resources.py
+++ b/kotti/resources.py
@@ -404,6 +404,8 @@ class TypeInfo(object):
         :rtype: Boolean
         """
 
+        if self.add_view is None:
+            return False
         if context.type_info.name in self.addable_to:
             return view_permitted(context, request, self.add_view)
         else:

--- a/kotti/tests/test_node.py
+++ b/kotti/tests/test_node.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 
+from mock import Mock
+from mock import patch
 from pyramid.security import ALL_PERMISSIONS
 from pyramid.security import Allow
 from pyramid.security import Deny
@@ -475,3 +477,12 @@ class TestTypeInfo:
         from kotti.resources import TypeInfo
         type_info = TypeInfo(add_permission='customadd')
         assert type_info.add_permission == 'customadd'
+
+    def test_type_info_unaddable(self):
+        from kotti.resources import TypeInfo
+        type_info = TypeInfo(add_view=None, addable_to=['Document'])
+        context = Mock(type_info=Mock())
+        context.type_info.name = 'Document'
+        with patch('kotti.resources.view_permitted') as vp:
+            res = type_info.addable(context, None)
+            assert vp.call_count == 0


### PR DESCRIPTION
This avoids a cryptic Pyramid error (that basically says "no such view None" that will occur when subclassing Content (which has add_view as None) and forgetting to set the add_view in type_info.