### PR TITLE
Avoid unnecessary file data overwrite when editing files

### DIFF
--- a/kotti/views/edit/content.py
+++ b/kotti/views/edit/content.py
@@ -95,13 +95,16 @@ class FileEditForm(EditFormView):
         form.appstruct = get_appstruct(self.context, self.schema)
         if self.context.data is not None:
             form.appstruct.update({'file': {
-                'fp': StringIO(self.context.data.file.read()),
-                'filename': self.context.name,
+                'fp': None,
+                'filename': self.context.data['filename'],  # self.context.name
                 'mimetype': self.context.mimetype,
                 'uid': str(random.randint(1000000000, 9999999999)),
             }})
 
     def schema_factory(self):
+        # File uploads are stored in the session so that you don't need
+        # to upload your file again if validation of another schema node
+        # fails.
         tmpstore = FileUploadTempStore(self.request)
         return FileSchema(tmpstore)
 
@@ -110,7 +113,7 @@ class FileEditForm(EditFormView):
         self.context.title = title
         self.context.description = appstruct['description']
         self.context.tags = appstruct['tags']
-        if appstruct['file']:
+        if appstruct['file'] and appstruct['file']['fp']:
             self.context.data = _to_fieldstorage(**appstruct['file'])
 
 


### PR DESCRIPTION
This PR aims to optimize the process of editing `File` instances. The problem it wants to solve is: when editing a file, even if the file data field is not changed, the file.data column is mutated anyway, which triggers a new Filedepot insert and delete of file data.

Why this happens: The File edit form saves in the session the whole file contents. It does this with the initial file content (as read from the disk or `DBStoredFile`, and when it shows up again, after a form validation error. The intention is very good, but this should be optimized. We want to be able to distinguish and only mutate the `data` column only when new file data is uploaded in the form. 

First, it's not really needed to save the initial data of the `File` in the session. We're only interested if that data changes. Then it's just a matter of checking the data set in the `FileUploadedTempStore`: we'll only set the `File.data` if some real data has been saved there.