### PR TITLE
remove pytest-warnings from test dependencies

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -31,6 +31,9 @@ Change History
 
 - Feature: add Czech translation.
 
+- remove pytest-warnings from test dependencies (already integrated in
+  modern pytest versions)
+
 1.3.0 - 2016-10-10
 ------------------
 

--- a/kotti/tests/test_filedepot.py
+++ b/kotti/tests/test_filedepot.py
@@ -279,13 +279,13 @@ class TestTween:
 
         # the attachments (created by the filters) are served by the
         # FiledepotServeApp
-        resp = webtest.app.get(img.data['thumb_128x128_url'])
+        resp = webtest.app.get(img.data[u'thumb_128x128_url'])
 
         assert resp.etag is not None
         assert resp.cache_control.max_age == 604800
         assert resp.body.startswith('\x89PNG')
 
-        resp = webtest.app.get(img.data['thumb_256x256_url'])
+        resp = webtest.app.get(img.data[u'thumb_256x256_url'])
         assert resp.etag is not None
         assert resp.cache_control.max_age == 604800
         assert resp.body.startswith('\x89PNG')
@@ -294,6 +294,6 @@ class TestTween:
         resp = webtest.app.get('/depot/non_existing/fileid', status=404)
         assert resp.status_code == 404
 
-        resp = webtest.app.get(img.data['thumb_256x256_url'] + 'not',
+        resp = webtest.app.get(img.data[u'thumb_256x256_url'] + 'not',
                                status=404)
         assert resp.status_code == 404

--- a/pytest.ini
+++ b/pytest.ini
@@ -17,3 +17,4 @@ pep8ignore = E501 E122 E123 E125 E128 E711 E713 E714 E402
 markers =
     user: mark test to be run as the given user
     slow: mark test to be run only with --runslow option
+    pep8: pep8 marker

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,6 @@ tests_require = [
     'pytest-pep8!=1.0.3',
     'pytest-travis-fold',
     'pytest-virtualenv',
-    'pytest-warnings',
     'pytest-xdist',
     'tox',
     'virtualenv',  # needed for scaffolding tests


### PR DESCRIPTION
It's already integrated in modern pytest versions