### PR TITLE
remove ancient unused dep: usersettings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -65,7 +65,6 @@ SQLAlchemy-Utils==0.36.8
 transaction==3.0.0
 translationstring==1.4
 Unidecode==1.1.1
-usersettings==1.0.7
 venusian==3.0.0
 waitress==1.4.4
 webencodings==0.5.1

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ install_requires = [
     'sqlalchemy-utils',
     'transaction>=1.1.0',
     'unidecode',
-    'usersettings',
     'waitress',
     'zope.deprecation',
     'zope.interface',


### PR DESCRIPTION
This PR removes the python module `usersettings` from the Kotti `requirements.txt` and `setup.py` files. This module is not used in the code anymore. It was added in #352 and it was subsequently removed when scaffolds were removed as part of the python3 update in #550 .

As mentioned in #348 :

> it's a very simple package (just ~100 LOC) that determines where to store user settings on various OSs. We use it to remember the last used answers to the questions asked during scaffolding.

I feel confident that usersettings isn't being used here, I wonder if other packages are similarly unused and can also be removed. I tried a couple checks (including trying and failing to get pycharm to report that) but didn't find anything that I am completely confident about.