### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/developing/advanced/blobs.rst
+++ b/docs/developing/advanced/blobs.rst
@@ -106,7 +106,7 @@ Method 2
 ~~~~~~~~
 
 Often these permission checks do not need to be enforced strictly.
-For such cases Kotti provides a "shortcut" in form of a Pyramid tween, that directly processes all requests under a certain path befor they even reach Kotti.
+For such cases Kotti provides a "shortcut" in form of a Pyramid tween, that directly processes all requests under a certain path before they even reach Kotti.
 This means: no traversal, no view lookup, no permission checks.
 The URL for this method can be created very similarily::
 

--- a/docs/developing/basic/configuration.rst
+++ b/docs/developing/basic/configuration.rst
@@ -295,7 +295,7 @@ URL normalization
 -----------------
 
 Kotti normalizes document titles to URLs by replacing language specific characters like umlauts or accented characters with its ascii equivalents.
-You can change this default behavour by setting ``kotti.url_normalizer.map_non_ascii_characters`` configuration variable to ``False``.
+You can change this default behaviour by setting ``kotti.url_normalizer.map_non_ascii_characters`` configuration variable to ``False``.
 If you do, Kotti will leave national characters in URLs.
 
 You may also replace default component used for url normalization by setting ``kotti.url_normalizer`` configuation variable.

--- a/kotti/filedepot.py
+++ b/kotti/filedepot.py
@@ -630,7 +630,7 @@ def adjust_for_engine(conn: Connection, branch: bool) -> None:
 
     # sqlite's Unicode columns return a buffer which can't be encoded by
     # a json encoder. We have to convert to a unicode string so that the value
-    # can be saved corectly by
+    # can be saved correctly by
     # :class:`depot.fields.sqlalchemy.upload.UploadedFile`
 
     # noinspection PyUnusedLocal

--- a/kotti/tests/__init__.py
+++ b/kotti/tests/__init__.py
@@ -77,7 +77,7 @@ def allwarnings(request):
 
 @fixture(scope="session")
 def custom_settings():
-    """This is a dummy fixture meant to be overriden in add on package's
+    """This is a dummy fixture meant to be overridden in add on package's
     ``conftest.py``.  It can be used to inject arbitrary settings for third
     party test suites.  The default settings dictionary will be updated
     with the dictionary returned by this fixture.


### PR DESCRIPTION
There are small typos in:
- docs/developing/advanced/blobs.rst
- docs/developing/basic/configuration.rst
- kotti/filedepot.py
- kotti/tests/__init__.py

Fixes:
- Should read `overridden` rather than `overriden`.
- Should read `correctly` rather than `corectly`.
- Should read `behaviour` rather than `behavour`.
- Should read `before` rather than `befor`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md